### PR TITLE
Improve chainer/__init__.py

### DIFF
--- a/chainerrl/__init__.py
+++ b/chainerrl/__init__.py
@@ -20,3 +20,38 @@ from chainerrl import recurrent  # NOQA
 from chainerrl import replay_buffer  # NOQA
 from chainerrl import v_function  # NOQA
 from chainerrl import v_functions  # NOQA
+
+# For backward compatibility while avoiding circular import
+policy.SoftmaxPolicy = policies.SoftmaxPolicy
+policy.FCSoftmaxPolicy = policies.FCSoftmaxPolicy
+policy.ContinuousDeterministicPolicy = policies.ContinuousDeterministicPolicy
+policy.FCDeterministicPolicy = policies.FCDeterministicPolicy
+policy.FCBNDeterministicPolicy = policies.FCBNDeterministicPolicy
+policy.FCLSTMDeterministicPolicy = policies.FCLSTMDeterministicPolicy
+policy.FCLSTMDeterministicPolicy = policies.FCLSTMDeterministicPolicy
+policy.GaussianPolicy = policies.GaussianPolicy
+policy.FCGaussianPolicy = policies.FCGaussianPolicy
+policy.LinearGaussianPolicyWithDiagonalCovariance = \
+    policies.LinearGaussianPolicyWithDiagonalCovariance
+policy.LinearGaussianPolicyWithSphericalCovariance = \
+    policies.LinearGaussianPolicyWithSphericalCovariance
+policy.MellowmaxPolicy = policies.MellowmaxPolicy
+
+q_function.DuelingDQN = q_functions.DuelingDQN
+q_function.SingleModelStateActionQFunction = \
+    q_functions.SingleModelStateActionQFunction
+q_function.FCSAQFunction = q_functions.FCSAQFunction
+q_function.FCLSTMSAQFunction = q_functions.FCLSTMSAQFunction
+q_function.FCBNSAQFunction = q_functions.FCBNSAQFunction
+q_function.FCBNLateActionSAQFunction = q_functions.FCBNLateActionSAQFunction
+q_function.FCLateActionSAQFunction = q_functions.FCLateActionSAQFunction
+q_function.SingleModelStateActionQFunction = \
+    q_functions.SingleModelStateActionQFunction
+q_function.FCStateQFunctionWithDiscreteAction = \
+    q_functions.FCStateQFunctionWithDiscreteAction
+q_function.FCLSTMStateQFunction = q_functions.FCLSTMStateQFunction
+q_function.FCSIContinuousQFunction = q_functions.FCSIContinuousQFunction
+q_function.FCBNSIContinuousQFunction = q_functions.FCBNSIContinuousQFunction
+
+v_function.SingleModelVFunction = v_functions.SingleModelVFunction
+v_function.FCVFunction = v_functions.FCVFunction

--- a/chainerrl/policies/__init__.py
+++ b/chainerrl/policies/__init__.py
@@ -1,4 +1,4 @@
-from chainerrl.policies.softmax_policy import *  # NOQA
-from chainerrl.policies.mellowmax_policy import *  # NOQA
-from chainerrl.policies.gaussian_policy import *  # NOQA
 from chainerrl.policies.deterministic_policy import *  # NOQA
+from chainerrl.policies.gaussian_policy import *  # NOQA
+from chainerrl.policies.mellowmax_policy import *  # NOQA
+from chainerrl.policies.softmax_policy import *  # NOQA

--- a/chainerrl/policy.py
+++ b/chainerrl/policy.py
@@ -22,8 +22,3 @@ class Policy(object):
             Distribution of actions
         """
         raise NotImplementedError()
-
-
-from chainerrl.policies.softmax_policy import *  # NOQA
-from chainerrl.policies.gaussian_policy import *  # NOQA
-from chainerrl.policies.deterministic_policy import *  # NOQA

--- a/chainerrl/q_function.py
+++ b/chainerrl/q_function.py
@@ -24,5 +24,3 @@ class StateActionQFunction(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def __call__(self, x, a, test=False):
         raise NotImplementedError()
-
-from chainerrl.q_functions import *  # NOQA

--- a/chainerrl/v_function.py
+++ b/chainerrl/v_function.py
@@ -17,5 +17,3 @@ class VFunction(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def __call__(self, x, test=False):
         raise NotImplementedError()
-
-from chainerrl.v_functions import *  # NOQA


### PR DESCRIPTION
Now you can use every module under chainerrl without explicitly importing it.
```
import chainerrl
q_func = chainerrl.q_function.DuelingDQN()
agent = chainerrl.agents.DQN(q_func, ...
```
This PR also removes circular import completely.