### PR TITLE
Remove clip_reward arguments from agents

### DIFF
--- a/chainerrl/agents/a3c.py
+++ b/chainerrl/agents/a3c.py
@@ -98,7 +98,7 @@ class A3C(agent.AttributeSavingMixin, agent.AsyncAgent):
     saved_attributes = ['model', 'optimizer']
 
     def __init__(self, model, optimizer, t_max, gamma, beta=1e-2,
-                 process_idx=0, clip_reward=True, phi=lambda x: x,
+                 process_idx=0, phi=lambda x: x,
                  pi_loss_coef=1.0, v_loss_coef=0.5,
                  keep_loss_scale_same=False,
                  normalize_grad_by_t_max=False,
@@ -121,7 +121,6 @@ class A3C(agent.AttributeSavingMixin, agent.AsyncAgent):
         self.t_max = t_max
         self.gamma = gamma
         self.beta = beta
-        self.clip_reward = clip_reward
         self.phi = phi
         self.pi_loss_coef = pi_loss_coef
         self.v_loss_coef = v_loss_coef
@@ -242,9 +241,6 @@ class A3C(agent.AttributeSavingMixin, agent.AsyncAgent):
 
     def act_and_train(self, state, reward):
 
-        if self.clip_reward:
-            reward = np.clip(reward, -1, 1)
-
         statevar = self.batch_states([state], np, self.phi)
 
         self.past_rewards[self.t - 1] = reward
@@ -284,9 +280,6 @@ class A3C(agent.AttributeSavingMixin, agent.AsyncAgent):
                 return pout.sample().data[0]
 
     def stop_episode_and_train(self, state, reward, done=False):
-        if self.clip_reward:
-            reward = np.clip(reward, -1, 1)
-
         self.past_rewards[self.t - 1] = reward
         if done:
             self.update(None)

--- a/chainerrl/agents/ddpg.py
+++ b/chainerrl/agents/ddpg.py
@@ -12,7 +12,6 @@ from logging import getLogger
 import chainer
 from chainer import cuda
 import chainer.functions as F
-import numpy as np
 
 from chainerrl.agent import Agent
 from chainerrl.agent import AttributeSavingMixin
@@ -75,7 +74,7 @@ class DDPG(AttributeSavingMixin, Agent):
                  gpu=None, replay_start_size=50000,
                  minibatch_size=32, update_frequency=1,
                  target_update_frequency=10000,
-                 clip_reward=True, phi=lambda x: x,
+                 phi=lambda x: x,
                  target_update_method='hard',
                  soft_update_tau=1e-2,
                  n_times_update=1, average_q_decay=0.999,
@@ -96,7 +95,6 @@ class DDPG(AttributeSavingMixin, Agent):
         self.explorer = explorer
         self.gpu = gpu
         self.target_update_frequency = target_update_frequency
-        self.clip_reward = clip_reward
         self.phi = phi
         self.target_update_method = target_update_method
         self.soft_update_tau = soft_update_tau
@@ -286,9 +284,6 @@ class DDPG(AttributeSavingMixin, Agent):
 
         self.logger.debug('t:%s r:%s', self.t, reward)
 
-        if self.clip_reward:
-            reward = np.clip(reward, -1, 1)
-
         greedy_action = self.act(state)
         action = self.explorer.select_action(self.t, lambda: greedy_action)
         self.t += 1
@@ -331,9 +326,6 @@ class DDPG(AttributeSavingMixin, Agent):
         return cuda.to_cpu(action.data[0])
 
     def stop_episode_and_train(self, state, reward, done=False):
-
-        if self.clip_reward:
-            reward = np.clip(reward, -1, 1)
 
         assert self.last_state is not None
         assert self.last_action is not None

--- a/chainerrl/agents/dqn.py
+++ b/chainerrl/agents/dqn.py
@@ -12,7 +12,6 @@ from logging import getLogger
 import chainer
 from chainer import cuda
 import chainer.functions as F
-import numpy as np
 
 from chainerrl import agent
 from chainerrl.misc.batch_states import batch_states
@@ -100,7 +99,7 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
                  explorer, gpu=None, replay_start_size=50000,
                  minibatch_size=32, update_frequency=1,
                  target_update_frequency=10000, clip_delta=True,
-                 clip_reward=True, phi=lambda x: x,
+                 phi=lambda x: x,
                  target_update_method='hard',
                  soft_update_tau=1e-2,
                  n_times_update=1, average_q_decay=0.999,
@@ -124,7 +123,6 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
         self.gpu = gpu
         self.target_update_frequency = target_update_frequency
         self.clip_delta = clip_delta
-        self.clip_reward = clip_reward
         self.phi = phi
         self.target_update_method = target_update_method
         self.soft_update_tau = soft_update_tau
@@ -317,9 +315,6 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
 
     def act_and_train(self, state, reward):
 
-        if self.clip_reward:
-            reward = np.clip(reward, -1, 1)
-
         greedy_action = self.act(state)
         action = self.explorer.select_action(self.t, lambda: greedy_action)
         self.t += 1
@@ -353,9 +348,6 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
 
         This function must be called once when an episode terminates.
         """
-
-        if self.clip_reward:
-            reward = np.clip(reward, -1, 1)
 
         assert self.last_state is not None
         assert self.last_action is not None

--- a/chainerrl/agents/nsq.py
+++ b/chainerrl/agents/nsq.py
@@ -45,7 +45,6 @@ class NSQ(AttributeSavingMixin, AsyncAgent):
 
     def __init__(self, q_function, optimizer,
                  t_max, gamma, i_target, explorer, phi=lambda x: x,
-                 clip_reward=True,
                  average_q_decay=0.999, logger=getLogger(__name__)):
 
         self.shared_q_function = q_function
@@ -60,7 +59,6 @@ class NSQ(AttributeSavingMixin, AsyncAgent):
         self.gamma = gamma
         self.explorer = explorer
         self.i_target = i_target
-        self.clip_reward = clip_reward
         self.phi = phi
         self.logger = logger
         self.average_q_decay = average_q_decay
@@ -130,9 +128,6 @@ class NSQ(AttributeSavingMixin, AsyncAgent):
 
     def act_and_train(self, obs, reward):
 
-        if self.clip_reward:
-            reward = np.clip(reward, -1, 1)
-
         statevar = chainer.Variable(np.expand_dims(self.phi(obs), 0))
 
         self.past_rewards[self.t - 1] = reward
@@ -174,9 +169,6 @@ class NSQ(AttributeSavingMixin, AsyncAgent):
         return qout.greedy_actions.data[0]
 
     def stop_episode_and_train(self, state, reward, done=False):
-        if self.clip_reward:
-            reward = np.clip(reward, -1, 1)
-
         self.past_rewards[self.t - 1] = reward
         if done:
             self.update(None)

--- a/chainerrl/agents/pgt.py
+++ b/chainerrl/agents/pgt.py
@@ -66,7 +66,7 @@ class PGT(AttributeSavingMixin, Agent):
                  gpu=-1, replay_start_size=50000,
                  minibatch_size=32, update_frequency=1,
                  target_update_frequency=10000,
-                 clip_reward=True, phi=lambda x: x,
+                 phi=lambda x: x,
                  target_update_method='hard',
                  soft_update_tau=1e-2,
                  n_times_update=1, average_q_decay=0.999,
@@ -85,7 +85,6 @@ class PGT(AttributeSavingMixin, Agent):
         self.explorer = explorer
         self.gpu = gpu
         self.target_update_frequency = target_update_frequency
-        self.clip_reward = clip_reward
         self.phi = phi
         self.target_update_method = target_update_method
         self.soft_update_tau = soft_update_tau
@@ -202,9 +201,6 @@ class PGT(AttributeSavingMixin, Agent):
 
         self.logger.debug('t:%s r:%s', self.t, reward)
 
-        if self.clip_reward:
-            reward = np.clip(reward, -1, 1)
-
         greedy_action = self.act(state)
         action = self.explorer.select_action(self.t, lambda: greedy_action)
         self.t += 1
@@ -250,9 +246,6 @@ class PGT(AttributeSavingMixin, Agent):
         return cuda.to_cpu(action.data[0])
 
     def stop_episode_and_train(self, state, reward, done=False):
-
-        if self.clip_reward:
-            reward = np.clip(reward, -1, 1)
 
         assert self.last_state is not None
         assert self.last_action is not None

--- a/chainerrl/misc/env_modifiers.py
+++ b/chainerrl/misc/env_modifiers.py
@@ -6,6 +6,8 @@ from future import standard_library
 from builtins import *  # NOQA
 standard_library.install_aliases()
 
+import numpy as np
+
 
 def make_rendered(env, *render_args, **render_kwargs):
     base_step = env.step
@@ -62,6 +64,10 @@ def make_reward_filtered(env, reward_filter):
         return observation, reward, done, info
 
     env.step = step
+
+
+def make_reward_clipped(env, low, high):
+    make_reward_filtered(env, lambda x: np.clip(x, low, high))
 
 
 def make_action_repeated(env, n_times):

--- a/examples/ale/train_a3c_ale.py
+++ b/examples/ale/train_a3c_ale.py
@@ -110,8 +110,11 @@ def main():
         agent.load(args.load)
 
     def make_env(process_idx, test):
-        return ale.ALE(args.rom, use_sdl=args.use_sdl,
-                       treat_life_lost_as_terminal=not test)
+        env = ale.ALE(args.rom, use_sdl=args.use_sdl,
+                      treat_life_lost_as_terminal=not test)
+        if not test:
+            misc.env_modifiers.make_reward_clipped(env, -1, 1)
+        return env
 
     if args.demo:
         env = make_env(0, True)

--- a/examples/ale/train_acer_ale.py
+++ b/examples/ale/train_acer_ale.py
@@ -10,7 +10,6 @@ import os
 
 import chainer
 from chainer import links as L
-import numpy as np
 
 from chainerrl.action_value import DiscreteActionValue
 from chainerrl.agents import acer
@@ -108,8 +107,7 @@ def main():
         env = ale.ALE(args.rom, use_sdl=args.use_sdl,
                       treat_life_lost_as_terminal=not test)
         if not test:
-            misc.env_modifiers.make_reward_filtered(
-                env, lambda x: np.clip(x, -1, 1))
+            misc.env_modifiers.make_reward_clipped(env, -1, 1)
 
         return env
 

--- a/examples/ale/train_dqn_ale.py
+++ b/examples/ale/train_dqn_ale.py
@@ -100,6 +100,7 @@ def main():
 
     # In training, life loss is considered as terminal states
     env = ale.ALE(args.rom, use_sdl=args.use_sdl)
+    misc.env_modifiers.make_reward_clipped(env, -1, 1)
     # In testing, an episode is terminated  when all lives are lost
     eval_env = ale.ALE(args.rom, use_sdl=args.use_sdl,
                        treat_life_lost_as_terminal=False)

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -7,8 +7,6 @@ from future import standard_library
 standard_library.install_aliases()
 
 import argparse
-from logging import getLogger
-logger = getLogger(__name__)
 import os
 import random
 
@@ -59,8 +57,11 @@ def main():
     print('Output files are saved in {}'.format(args.outdir))
 
     def make_env(process_idx, test):
-        return ale.ALE(args.rom, use_sdl=args.use_sdl,
-                       treat_life_lost_as_terminal=not test)
+        env = ale.ALE(args.rom, use_sdl=args.use_sdl,
+                      treat_life_lost_as_terminal=not test)
+        if not test:
+            misc.env_modifiers.make_reward_clipped(env, -1, 1)
+        return env
 
     sample_env = make_env(0, test=False)
     action_space = sample_env.action_space


### PR DESCRIPTION
Add make_reward_clipped for ALE examples instead.

If you are setting `clip_reward=True`, remove it and apply `chainerrl.misc.env_modifiers.make_reward_clipped` instead.
If you are setting `clip_reward=False`, just remove it.