### PR TITLE
support python3.4 for random.sample with deque

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ language: python
 cache: pip
 python:
   - "2.7"
+  - "3.4"
   - "3.5.1"
+env:
+matrix:
+  allow_failures:
+    - python: "3.4"
 # command to install dependencies
 install:
   - pip install --upgrade pip setuptools wheel

--- a/chainerrl/replay_buffer.py
+++ b/chainerrl/replay_buffer.py
@@ -6,6 +6,8 @@ from builtins import *  # NOQA
 from future import standard_library
 standard_library.install_aliases()
 from collections import deque
+from distutils.version import LooseVersion
+import platform
 import random
 
 import numpy as np
@@ -40,7 +42,11 @@ class ReplayBuffer(object):
     def sample(self, n):
         """Sample n unique samples from this replay buffer"""
         assert len(self.memory) >= n
-        return random.sample(self.memory, n)
+        if (LooseVersion('3.5') > LooseVersion(platform.python_version()) and
+                LooseVersion(platform.python_version()) > LooseVersion('3.0')):
+            return random.sample(list(self.memory), n)
+        else:
+            return random.sample(self.memory, n)
 
     def __len__(self):
         return len(self.memory)
@@ -169,12 +175,20 @@ class EpisodicReplayBuffer(object):
     def sample(self, n):
         """Sample n unique samples from this replay buffer"""
         assert len(self.memory) >= n
-        return random.sample(self.memory, n)
+        if (LooseVersion('3.5') > LooseVersion(platform.python_version()) and
+                LooseVersion(platform.python_version()) > LooseVersion('3.0')):
+            return random.sample(list(self.memory), n)
+        else:
+            return random.sample(self.memory, n)
 
     def sample_episodes(self, n_episodes, max_len=None):
         """Sample n unique samples from this replay buffer"""
         assert len(self.episodic_memory) >= n_episodes
-        episodes = random.sample(self.episodic_memory, n_episodes)
+        if (LooseVersion('3.5') > LooseVersion(platform.python_version()) and
+                LooseVersion(platform.python_version()) > LooseVersion('3.0')):
+            episodes = random.sample(list(self.episodic_memory), n_episodes)
+        else:
+            episodes = random.sample(self.episodic_memory, n_episodes)
         if max_len is not None:
             return [random_subseq(ep, max_len) for ep in episodes]
         else:


### PR DESCRIPTION
 with `Python3.4`, it causes error below.
```python
Traceback (most recent call last):
  File "quickstart.py", line 111, in <module>
    action = agent.act_and_train(obs, reward)
  File "/opt/rl/lib/python3.4/site-packages/chainerrl/agents/dqn.py", line 340, in act_and_train
    self.replay_updator.update_if_necessary(self.t)
  File "/opt/rl/lib/python3.4/site-packages/chainerrl/replay_buffer.py", line 194, in update_if_necessary
    transitions = self.replay_buffer.sample(self.batchsize)
  File "/opt/rl/lib/python3.4/site-packages/chainerrl/replay_buffer.py", line 42, in sample
    return random.sample(self.memory, n)
  File "/opt/rl/lib/python3.4/random.py", line 311, in sample
    raise TypeError("Population must be a sequence or set.  For dicts, use list(d).")
TypeError: Population must be a sequence or set.  For dicts, use list(d).
```

I know `Python3.4` is not officially supported, but I only have this bug with `python3.4` and everything works fine, so i thought it is pity to remain this and block `python3.4` users.