### PR TITLE
Fix REINFORCE's missing initialization of t

### DIFF
--- a/chainerrl/agents/reinforce.py
+++ b/chainerrl/agents/reinforce.py
@@ -67,6 +67,7 @@ class REINFORCE(agent.AttributeSavingMixin, agent.Agent):
         # Statistics
         self.average_entropy = 0
 
+        self.t = 0
         self.reward_sequences = [[]]
         self.log_prob_sequences = [[]]
         self.entropy_sequences = [[]]

--- a/chainerrl/experiments/train_agent.py
+++ b/chainerrl/experiments/train_agent.py
@@ -42,7 +42,8 @@ def train_agent(agent, env, steps, outdir, max_episode_len=None,
     done = False
 
     t = step_offset
-    agent.t = step_offset
+    if hasattr(agent, 't'):
+        agent.t = step_offset
 
     episode_len = 0
     try:


### PR DESCRIPTION
REINFORCE doesn't have code to initialize `self.t`. The problem has been not found because `chainer.experiemnts.train_agent` sets it, but agents should be self-contained.