### PR TITLE
Support nesting AttributeSavingMixin

### DIFF
--- a/chainerrl/agent.py
+++ b/chainerrl/agent.py
@@ -115,7 +115,7 @@ class AttributeSavingMixin(object):
             assert hasattr(self, attr)
             attr_value = getattr(self, attr)
             if isinstance(attr_value, AttributeSavingMixin):
-                assert attr_value != self, "Avoid an infinite loop"
+                assert attr_value is not self, "Avoid an infinite loop"
                 attr_value.save(os.path.join(dirname, attr))
             else:
                 serializers.save_npz(
@@ -128,7 +128,7 @@ class AttributeSavingMixin(object):
             assert hasattr(self, attr)
             attr_value = getattr(self, attr)
             if isinstance(attr_value, AttributeSavingMixin):
-                assert attr_value != self, "Avoid an infinite loop"
+                assert attr_value is not self, "Avoid an infinite loop"
                 attr_value.load(os.path.join(dirname, attr))
             else:
                 """Fix Chainer Issue #2772

--- a/chainerrl/agent.py
+++ b/chainerrl/agent.py
@@ -112,21 +112,33 @@ class AttributeSavingMixin(object):
         """Save internal states."""
         makedirs(dirname, exist_ok=True)
         for attr in self.saved_attributes:
-            serializers.save_npz(
-                os.path.join(dirname, '{}.npz'.format(attr)),
-                getattr(self, attr))
+            assert hasattr(self, attr)
+            attr_value = getattr(self, attr)
+            if isinstance(attr_value, AttributeSavingMixin):
+                assert attr_value != self, "Avoid an infinite loop"
+                attr_value.save(os.path.join(dirname, attr))
+            else:
+                serializers.save_npz(
+                    os.path.join(dirname, '{}.npz'.format(attr)),
+                    getattr(self, attr))
 
     def load(self, dirname):
         """Load internal states."""
         for attr in self.saved_attributes:
-            """Fix Chainer Issue #2772
+            assert hasattr(self, attr)
+            attr_value = getattr(self, attr)
+            if isinstance(attr_value, AttributeSavingMixin):
+                assert attr_value != self, "Avoid an infinite loop"
+                attr_value.load(os.path.join(dirname, attr))
+            else:
+                """Fix Chainer Issue #2772
 
-            In Chainer v2, a (stateful) optimizer cannot be loaded from
-            an npz saved before the first update.
-            """
-            load_npz_no_strict(
-                os.path.join(dirname, '{}.npz'.format(attr)),
-                getattr(self, attr))
+                In Chainer v2, a (stateful) optimizer cannot be loaded from
+                an npz saved before the first update.
+                """
+                load_npz_no_strict(
+                    os.path.join(dirname, '{}.npz'.format(attr)),
+                    getattr(self, attr))
 
 
 class AsyncAgent(with_metaclass(ABCMeta, Agent)):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -49,14 +49,15 @@ class TestAttributeSavingMixin(unittest.TestCase):
         # Save
         dirname = tempfile.mkdtemp()
         parent.save(dirname)
-        assert os.path.isdir(dirname)
-        assert os.path.isfile(os.path.join(dirname, 'link.npz'))
-        assert os.path.isdir(os.path.join(dirname, 'child'))
-        assert os.path.isfile(os.path.join(dirname, 'child', 'link.npz'))
+        self.assertTrue(os.path.isdir(dirname))
+        self.assertTrue(os.path.isfile(os.path.join(dirname, 'link.npz')))
+        self.assertTrue(os.path.isdir(os.path.join(dirname, 'child')))
+        self.assertTrue(os.path.isfile(
+            os.path.join(dirname, 'child', 'link.npz')))
         # Load
         parent = Parent()
-        assert int(parent.link.param.data) == 0
-        assert int(parent.child.link.param.data) == 0
+        self.assertEqual(int(parent.link.param.data), 0)
+        self.assertEqual(int(parent.child.link.param.data), 0)
         parent.load(dirname)
-        assert int(parent.link.param.data) == 1
-        assert int(parent.child.link.param.data) == 2
+        self.assertEqual(int(parent.link.param.data), 1)
+        self.assertEqual(int(parent.child.link.param.data), 2)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,62 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()
+
+import os
+import tempfile
+import unittest
+
+import chainer
+import numpy as np
+
+import chainerrl
+
+
+def create_simple_link():
+    link = chainer.Link()
+    with link.init_scope():
+        link.param = chainer.Parameter(np.zeros(1))
+    return link
+
+
+class Parent(chainerrl.agent.AttributeSavingMixin, object):
+
+    saved_attributes = ['link', 'child']
+
+    def __init__(self):
+        self.link = create_simple_link()
+        self.child = Child()
+
+
+class Child(chainerrl.agent.AttributeSavingMixin, object):
+
+    saved_attributes = ['link']
+
+    def __init__(self):
+        self.link = create_simple_link()
+
+
+class TestAttributeSavingMixin(unittest.TestCase):
+
+    def test_save_load(self):
+        parent = Parent()
+        parent.link.param.data[:] = 1
+        parent.child.link.param.data[:] = 2
+        # Save
+        dirname = tempfile.mkdtemp()
+        parent.save(dirname)
+        assert os.path.isdir(dirname)
+        assert os.path.isfile(os.path.join(dirname, 'link.npz'))
+        assert os.path.isdir(os.path.join(dirname, 'child'))
+        assert os.path.isfile(os.path.join(dirname, 'child', 'link.npz'))
+        # Load
+        parent = Parent()
+        assert int(parent.link.param.data[:]) == 0
+        assert int(parent.child.link.param.data[:]) == 0
+        parent.load(dirname)
+        assert int(parent.link.param.data[:]) == 1
+        assert int(parent.child.link.param.data[:]) == 2

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -55,8 +55,8 @@ class TestAttributeSavingMixin(unittest.TestCase):
         assert os.path.isfile(os.path.join(dirname, 'child', 'link.npz'))
         # Load
         parent = Parent()
-        assert int(parent.link.param.data[:]) == 0
-        assert int(parent.child.link.param.data[:]) == 0
+        assert int(parent.link.param.data) == 0
+        assert int(parent.child.link.param.data) == 0
         parent.load(dirname)
-        assert int(parent.link.param.data[:]) == 1
-        assert int(parent.child.link.param.data[:]) == 2
+        assert int(parent.link.param.data) == 1
+        assert int(parent.child.link.param.data) == 2


### PR DESCRIPTION
This PR enables nesting  AttributeSavingMixin so that agents can have child agents.