### PR TITLE
[WIP] Improve batch_states to support cupy.ndarray as observations

### DIFF
--- a/chainerrl/misc/batch_states.py
+++ b/chainerrl/misc/batch_states.py
@@ -1,3 +1,7 @@
+import chainer
+import numpy
+
+
 def batch_states(states, xp, phi):
     """The default method for making batch of observations.
 
@@ -11,4 +15,10 @@ def batch_states(states, xp, phi):
     """
 
     states = [phi(s) for s in states]
-    return xp.asarray(states)
+    if chainer.cuda.get_array_module(states[0]) == numpy:
+        # xp can be numpy or cupy
+        return xp.asarray(states)
+    else:
+        # xp must be cupy when observation is in gpu
+        assert xp == chainer.cuda.cupy
+        return xp.stack(states)

--- a/chainerrl/misc/batch_states.py
+++ b/chainerrl/misc/batch_states.py
@@ -14,11 +14,14 @@ def batch_states(states, xp, phi):
         the object which will be given as input to the model.
     """
 
-    states = [phi(s) for s in states]
-    if chainer.cuda.get_array_module(states[0]) == numpy:
-        # xp can be numpy or cupy
-        return xp.asarray(states)
-    else:
-        # xp must be cupy when observation is in gpu
+    encoded_states = [phi(s) for s in states]
+    if any(chainer.cuda.get_array_module(s) is chainer.cuda.cupy
+            for s in encoded_states):
+        # xp must be cupy when some of observations is in gpu
         assert xp == chainer.cuda.cupy
-        return xp.stack(states)
+        return xp.stack([xp.asarray(s) for s in encoded_states])
+    elif xp == numpy:
+        # All elements should be numpy.ndarray
+        return xp.stack(encoded_states)
+    else:
+        return xp.asarray(encoded_states)

--- a/tests/misc_tests/test_batch_states.py
+++ b/tests/misc_tests/test_batch_states.py
@@ -1,0 +1,49 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+import unittest
+
+import chainer
+from chainer import testing
+from chainer.testing import attr
+from chainer.testing import condition
+
+import numpy as np
+
+from chainerrl.misc.batch_states import batch_states
+
+
+@testing.parameterize(*testing.product({
+    'n_states': [1, 10],
+    'obs_shape': [(1,),  (3,), (3, 2)],
+}))
+class TestBatchStates(unittest.TestCase):
+
+    def _test_batch_states(self, input_xp, output_xp):
+        observations = [input_xp.ones(self.obs_shape)
+                        for _ in range(self.n_states)]
+
+        def phi(x):
+            # identity
+            return x
+
+        batch = batch_states(observations, xp=output_xp, phi=phi)
+        self.assertTrue(isinstance(batch, output_xp.ndarray))
+        expected_output_shape = (self.n_states,) + self.obs_shape
+        self.assertEqual(batch.shape, expected_output_shape)
+        testing.assert_allclose(
+            batch, output_xp.ones(expected_output_shape))
+
+    def test_batch_states_numpy_to_numpy(self):
+        self._test_batch_states(np, np)
+
+    @attr.gpu
+    def test_batch_states_numpy_to_cupy(self):
+        self._test_batch_states(np, chainer.cuda.cupy)
+
+    @attr.gpu
+    def test_batch_states_cupy_to_cupy(self):
+        self._test_batch_states(chainer.cuda.cupy, chainer.cuda.cupy)

--- a/tests/misc_tests/test_batch_states.py
+++ b/tests/misc_tests/test_batch_states.py
@@ -9,7 +9,6 @@ import unittest
 import chainer
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 import numpy as np
 


### PR DESCRIPTION
This PR enables `batch_states` to accept `cupy.ndarray`s so that you can use `cupy.ndarray` as observations.