### PR TITLE
[policies/gaussian_policy] Improve docstring

### DIFF
--- a/chainerrl/policies/gaussian_policy.py
+++ b/chainerrl/policies/gaussian_policy.py
@@ -142,8 +142,6 @@ class FCGaussianPolicyWithFixedCovariance(links.Sequence, GaussianPolicy):
         n_hidden_channels (int): Number of hidden channels.
         min_action (ndarray): Minimum action. Used only when bound_mean=True.
         max_action (ndarray): Maximum action. Used only when bound_mean=True.
-        var_type (str): Type of parameterization of variance. It must be
-            'spherical' or 'diagonal'.
         nonlinearity (callable): Nonlinearity placed between layers.
         mean_wscale (float): Scale of weight initialization of the mean layer.
     """


### PR DESCRIPTION
Deleted var_type from FCGaussianPolicyWithFixedCovariance 's docstring, 
because that's argument does not exist.
https://github.com/chainer/chainerrl/blob/master/chainerrl/policies/gaussian_policy.py#L130-L154