### PR TITLE
Use DQN.act method in DQN.act_and_train to remove code duplication

### DIFF
--- a/chainerrl/agents/dqn.py
+++ b/chainerrl/agents/dqn.py
@@ -402,21 +402,7 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
         return action
 
     def act_and_train(self, state, reward):
-
-        with chainer.using_config('train', False):
-            with chainer.no_backprop_mode():
-                action_value = self.model(
-                    self.batch_states([state], self.xp, self.phi))
-                q = float(action_value.max.data)
-                greedy_action = cuda.to_cpu(action_value.greedy_actions.data)[
-                    0]
-
-        # Update stats
-        self.average_q *= self.average_q_decay
-        self.average_q += (1 - self.average_q_decay) * q
-
-        self.logger.debug('t:%s q:%s action_value:%s', self.t, q, action_value)
-
+        greedy_action = self.act(state)
         action = self.explorer.select_action(
             self.t, lambda: greedy_action, action_value=action_value)
         self.t += 1


### PR DESCRIPTION
The first part of `DQN.act_and_train` is exactly identical to what `DQN.act` does. This PR changes `DQN.act_and_train` to use its `act` method to get a greedy action.