### PR TITLE
Add a utility function to draw a computational graph

### DIFF
--- a/chainerrl/action_value.py
+++ b/chainerrl/action_value.py
@@ -10,6 +10,7 @@ standard_library.install_aliases()
 from abc import ABCMeta
 from abc import abstractmethod
 from abc import abstractproperty
+import warnings
 
 from cached_property import cached_property
 import chainer
@@ -220,6 +221,9 @@ class SingleActionValue(ActionValue):
 
     @property
     def params(self):
-        # SingleActionValue has no learnable parameters until it is evaluated
-        # on some action.
+        warnings.warn(
+            'SingleActionValue has no learnable parameters until it'
+            ' is evaluated on some action. If you want to draw a computation'
+            ' graph that outputs SingleActionValue, use the variable returned'
+            ' by its method such as evaluate_actions instead.')
         return ()

--- a/chainerrl/action_value.py
+++ b/chainerrl/action_value.py
@@ -41,6 +41,15 @@ class ActionValue(with_metaclass(ABCMeta, object)):
         """Evaluate Q(s,a) with a = given actions."""
         raise NotImplementedError()
 
+    @abstractproperty
+    def params(self):
+        """Learnable parameters of this action value.
+
+        Returns:
+            tuple of chainer.Variable
+        """
+        raise NotImplementedError()
+
 
 class DiscreteActionValue(ActionValue):
     """Q-function output for discrete action space.
@@ -94,6 +103,10 @@ class DiscreteActionValue(ActionValue):
         return 'DiscreteActionValue greedy_actions:{} q_values:{}'.format(
             self.greedy_actions.data,
             self.q_values_formatter(self.q_values.data))
+
+    @property
+    def params(self):
+        return (self.q_values,)
 
 
 class QuadraticActionValue(ActionValue):
@@ -164,6 +177,10 @@ class QuadraticActionValue(ActionValue):
         return 'QuadraticActionValue greedy_actions:{} v:{}'.format(
             self.greedy_actions.data, self.v.data)
 
+    @property
+    def params(self):
+        return (self.mu, self.mat, self.v)
+
 
 class SingleActionValue(ActionValue):
     """ActionValue that can evaluate only a single action."""
@@ -194,3 +211,9 @@ class SingleActionValue(ActionValue):
 
     def __repr__(self):
         return 'SingleActionValue'
+
+    @property
+    def params(self):
+        # SingleActionValue has no learnable parameters until it is evaluated
+        # on some action.
+        return ()

--- a/chainerrl/experiments/__init__.py
+++ b/chainerrl/experiments/__init__.py
@@ -3,7 +3,6 @@ from chainerrl.experiments.evaluator import eval_performance  # NOQA
 from chainerrl.experiments.hooks import LinearInterpolationHook  # NOQA
 from chainerrl.experiments.hooks import StepHook  # NOQA
 
-from chainerrl.experiments.prepare_output_dir import is_return_code_zero  # NOQA
 from chainerrl.experiments.prepare_output_dir import is_under_git_control  # NOQA
 from chainerrl.experiments.prepare_output_dir import prepare_output_dir  # NOQA
 

--- a/chainerrl/experiments/prepare_output_dir.py
+++ b/chainerrl/experiments/prepare_output_dir.py
@@ -13,27 +13,12 @@ import subprocess
 import sys
 import tempfile
 
-
-def is_return_code_zero(args):
-    """Return true iff the given command's return code is zero.
-
-    All the messages to stdout or stderr are suppressed.
-    """
-    FNULL = open(os.devnull, 'w')
-    try:
-        subprocess.check_call(args, stdout=FNULL, stderr=FNULL)
-    except subprocess.CalledProcessError:
-        # The given command returned an error
-        return False
-    except OSError:
-        # The given command was not found
-        return False
-    return True
+import chainerrl
 
 
 def is_under_git_control():
     """Return true iff the current directory is under git control."""
-    return is_return_code_zero(['git', 'rev-parse'])
+    return chainerrl.misc.is_return_code_zero(['git', 'rev-parse'])
 
 
 def prepare_output_dir(args, user_specified_dir=None, argv=None,

--- a/chainerrl/misc/__init__.py
+++ b/chainerrl/misc/__init__.py
@@ -1,7 +1,7 @@
 from chainerrl.misc.batch_states import batch_states  # NOQA
 from chainerrl.misc.draw_computational_graph import collect_variables  # NOQA
-from chainerrl.misc.draw_computational_graph import is_graphviz_available  # NOQA
 from chainerrl.misc.draw_computational_graph import draw_computational_graph  # NOQA
+from chainerrl.misc.draw_computational_graph import is_graphviz_available  # NOQA
 from chainerrl.misc import env_modifiers  # NOQA
 from chainerrl.misc.is_return_code_zero import is_return_code_zero  # NOQA
 from chainerrl.misc.random_seed import set_random_seed  # NOQA

--- a/chainerrl/misc/__init__.py
+++ b/chainerrl/misc/__init__.py
@@ -1,4 +1,7 @@
 from chainerrl.misc.batch_states import batch_states  # NOQA
+from chainerrl.misc.draw_computational_graph import collect_variables  # NOQA
+from chainerrl.misc.draw_computational_graph import is_graphviz_available  # NOQA
 from chainerrl.misc.draw_computational_graph import draw_computational_graph  # NOQA
 from chainerrl.misc import env_modifiers  # NOQA
+from chainerrl.misc.is_return_code_zero import is_return_code_zero  # NOQA
 from chainerrl.misc.random_seed import set_random_seed  # NOQA

--- a/chainerrl/misc/__init__.py
+++ b/chainerrl/misc/__init__.py
@@ -1,3 +1,4 @@
 from chainerrl.misc.batch_states import batch_states  # NOQA
+from chainerrl.misc.draw_computational_graph import draw_computational_graph  # NOQA
 from chainerrl.misc import env_modifiers  # NOQA
 from chainerrl.misc.random_seed import set_random_seed  # NOQA

--- a/chainerrl/misc/draw_computational_graph.py
+++ b/chainerrl/misc/draw_computational_graph.py
@@ -42,8 +42,8 @@ def draw_computational_graph(outputs, filepath):
     """Draw a computational graph and write to a given file.
 
     Args:
-        outputs (object): Output(s) of the computational graph. Each
-            item must be Variable, ActionValue, Distribution or list of them.
+        outputs (object): Output(s) of the computational graph. It must be
+            a Variable, an ActionValue, a Distribution or a list of them.
         filepath (str): Filepath to write a graph without file extention.
             A DOT file will be saved with ".gv" extension added.
             If Graphviz's dot command is available, a PNG file will also be

--- a/chainerrl/misc/draw_computational_graph.py
+++ b/chainerrl/misc/draw_computational_graph.py
@@ -1,0 +1,54 @@
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()
+
+import subprocess
+import tempfile
+
+import chainer.computational_graph
+import chainerrl
+
+
+def collect_variables(obj):
+    variables = []
+    if isinstance(obj, chainer.Variable):
+        return [obj]
+    elif isinstance(obj, chainerrl.action_value.ActionValue):
+        return [obj.greedy_actions(), obj.max()]
+    elif isinstance(obj, chainerrl.distribution.Distribution):
+        return obj.params
+    elif isinstance(obj, (list, tuple)):
+        variables = []
+        for child in obj:
+            variables.extend(collect_variables(child))
+        return variables
+
+
+def draw_computational_graph(outputs, filepath):
+    """Draw a computational graph and write to a given file.
+
+    Args:
+        outputs (object): Output(s) of the computational graph. Each
+            item must be Variable, ActionValue, Distribution or list of them.
+        filepath (str): Filepath to write a graph.
+            If it ends with ".dot", it will be in the dot format.
+            If it ends with ".png", in the png format.
+    """
+    variables = collect_variables(outputs)
+    g = chainer.computational_graph.build_computational_graph(variables)
+    if filepath.lower().endswith('.dot'):
+        with open(filepath, 'w') as f:
+            f.write(g.dump())
+    elif filepath.lower().endswith('.png'):
+        with tempfile.NamedTemporaryFile(mode='w') as f:
+            f.write(g.dump())
+            f.file.close()
+            subprocess.check_call(['dot', '-Tpng', f.name, '-o', filepath])
+    else:
+        raise RuntimeError(
+            'filepath should end with ".dot" or ".png", but is {}'.format(
+                filepath))

--- a/chainerrl/misc/draw_computational_graph.py
+++ b/chainerrl/misc/draw_computational_graph.py
@@ -53,7 +53,9 @@ def draw_computational_graph(outputs, filepath):
     g = chainer.computational_graph.build_computational_graph(variables)
     gv_filepath = filepath + '.gv'
     with open(gv_filepath, 'w') as f:
-        f.write(g.dump())
+        # future.builtins.str is required to make sure the content is unicode
+        # in both py2 and py3
+        f.write(str(g.dump()))
     if is_graphviz_available():
         png_filepath = filepath + '.png'
         subprocess.check_call(

--- a/chainerrl/misc/draw_computational_graph.py
+++ b/chainerrl/misc/draw_computational_graph.py
@@ -24,7 +24,7 @@ def collect_variables(obj):
     if isinstance(obj, chainer.Variable):
         return [obj]
     elif isinstance(obj, chainerrl.action_value.ActionValue):
-        return [obj.greedy_actions, obj.max]
+        return list(obj.params)
     elif isinstance(obj, chainerrl.distribution.Distribution):
         return list(obj.params)
     elif isinstance(obj, (list, tuple)):

--- a/chainerrl/misc/is_return_code_zero.py
+++ b/chainerrl/misc/is_return_code_zero.py
@@ -1,0 +1,26 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+import os
+import subprocess
+
+
+def is_return_code_zero(args):
+    """Return true iff the given command's return code is zero.
+
+    All the messages to stdout or stderr are suppressed.
+    """
+    FNULL = open(os.devnull, 'w')
+    try:
+        subprocess.check_call(args, stdout=FNULL, stderr=FNULL)
+    except subprocess.CalledProcessError:
+        # The given command returned an error
+        return False
+    except OSError:
+        # The given command was not found
+        return False
+    return True

--- a/chainerrl/misc/is_return_code_zero.py
+++ b/chainerrl/misc/is_return_code_zero.py
@@ -14,13 +14,13 @@ def is_return_code_zero(args):
 
     All the messages to stdout or stderr are suppressed.
     """
-    FNULL = open(os.devnull, 'w')
-    try:
-        subprocess.check_call(args, stdout=FNULL, stderr=FNULL)
-    except subprocess.CalledProcessError:
-        # The given command returned an error
-        return False
-    except OSError:
-        # The given command was not found
-        return False
-    return True
+    with open(os.devnull, 'wb') as FNULL:
+        try:
+            subprocess.check_call(args, stdout=FNULL, stderr=FNULL)
+        except subprocess.CalledProcessError:
+            # The given command returned an error
+            return False
+        except OSError:
+            # The given command was not found
+            return False
+        return True

--- a/examples/gym/train_reinforce_gym.py
+++ b/examples/gym/train_reinforce_gym.py
@@ -17,6 +17,7 @@ from builtins import *  # NOQA
 from future import standard_library
 standard_library.install_aliases()
 import argparse
+import os
 
 import chainer
 import gym
@@ -97,6 +98,11 @@ def main():
             n_hidden_layers=2,
             nonlinearity=chainer.functions.leaky_relu,
         )
+
+    # Visualize the model
+    chainerrl.misc.draw_computational_graph(
+        [model(np.zeros_like(obs_space.low, dtype=np.float32)[None])],
+        os.path.join(args.outdir, 'model.png'))
 
     if args.gpu >= 0:
         chainer.cuda.get_device(args.gpu).use()

--- a/examples/gym/train_reinforce_gym.py
+++ b/examples/gym/train_reinforce_gym.py
@@ -102,7 +102,7 @@ def main():
     # Visualize the model
     chainerrl.misc.draw_computational_graph(
         [model(np.zeros_like(obs_space.low, dtype=np.float32)[None])],
-        os.path.join(args.outdir, 'model.png'))
+        os.path.join(args.outdir, 'model'))
 
     if args.gpu >= 0:
         chainer.cuda.get_device(args.gpu).use()

--- a/examples/gym/train_reinforce_gym.py
+++ b/examples/gym/train_reinforce_gym.py
@@ -99,7 +99,7 @@ def main():
             nonlinearity=chainer.functions.leaky_relu,
         )
 
-    # Visualize the model
+    # Draw the computational graph and save it in the output directory.
     chainerrl.misc.draw_computational_graph(
         [model(np.zeros_like(obs_space.low, dtype=np.float32)[None])],
         os.path.join(args.outdir, 'model'))

--- a/tests/experiments_tests/test_prepare_output_dir.py
+++ b/tests/experiments_tests/test_prepare_output_dir.py
@@ -25,17 +25,6 @@ def work_dir(dirname):
     os.chdir(orig_dir)
 
 
-class TestIsReturnCodeZero(unittest.TestCase):
-
-    def test(self):
-        # Assume ls command exists
-        self.assertTrue(chainerrl.experiments.is_return_code_zero(['ls']))
-        self.assertFalse(chainerrl.experiments.is_return_code_zero(
-            ['ls --nonexistentoption']))
-        self.assertFalse(chainerrl.experiments.is_return_code_zero(
-            ['nonexistentcommand']))
-
-
 class TestIsUnderGitControl(unittest.TestCase):
 
     def test(self):

--- a/tests/misc_tests/test_draw_computational_graph.py
+++ b/tests/misc_tests/test_draw_computational_graph.py
@@ -1,0 +1,88 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+import os
+import tempfile
+import unittest
+
+import chainer
+import numpy as np
+
+import chainerrl
+
+
+class TestDrawComputationalGraph(unittest.TestCase):
+
+    def test_collect_variables(self):
+        # Empty list
+        vs = chainerrl.misc.collect_variables([])
+        self.assertEqual(vs, [])
+
+        vs = chainerrl.misc.collect_variables([[]])
+        self.assertEqual(vs, [])
+
+        # Empty tuple
+        vs = chainerrl.misc.collect_variables(())
+        self.assertEqual(vs, [])
+
+        vs = chainerrl.misc.collect_variables(((),))
+        self.assertEqual(vs, [])
+
+        # Variable
+        v = chainer.Variable(np.zeros(5))
+
+        vs = chainerrl.misc.collect_variables(v)
+        self.assertEqual(vs, [v])
+
+        vs = chainerrl.misc.collect_variables([v])
+        self.assertEqual(vs, [v])
+
+        vs = chainerrl.misc.collect_variables([[v]])
+        self.assertEqual(vs, [v])
+
+        # ActionValue
+        av = chainerrl.action_value.DiscreteActionValue(
+            chainer.Variable(np.zeros((5, 5))))
+
+        vs = chainerrl.misc.collect_variables(av)
+        self.assertEqual(vs, [av.greedy_actions, av.max])
+
+        vs = chainerrl.misc.collect_variables([av])
+        self.assertEqual(vs, [av.greedy_actions, av.max])
+
+        vs = chainerrl.misc.collect_variables([[av]])
+        self.assertEqual(vs, [av.greedy_actions, av.max])
+
+        # Distribution
+        dis = chainerrl.distribution.SoftmaxDistribution(
+            chainer.Variable(np.zeros((5, 5))))
+
+        vs = chainerrl.misc.collect_variables(dis)
+        self.assertEqual(vs, list(dis.params))
+
+        vs = chainerrl.misc.collect_variables([dis])
+        self.assertEqual(vs, list(dis.params))
+
+        vs = chainerrl.misc.collect_variables([[dis]])
+        self.assertEqual(vs, list(dis.params))
+
+        # All
+        vs = chainerrl.misc.collect_variables([v, av, dis])
+        self.assertEqual(vs, [v, av.greedy_actions, av.max]
+                         + list(dis.params))
+
+    def test_draw_computational_graph(self):
+        x = chainer.Variable(np.zeros(5))
+        y = x ** 2 + chainer.Variable(np.ones(5))
+        with tempfile.TemporaryDirectory() as d:
+            filepath = os.path.join(d, 'graph')
+            chainerrl.misc.draw_computational_graph(y, filepath)
+            self.assertTrue(os.path.exists(filepath + '.gv'))
+            if chainerrl.misc.is_graphviz_available():
+                self.assertTrue(os.path.exists(filepath + '.png'))
+            else:
+                self.assertFalse(os.path.exists(filepath + '.png'))

--- a/tests/misc_tests/test_draw_computational_graph.py
+++ b/tests/misc_tests/test_draw_computational_graph.py
@@ -7,6 +7,7 @@ standard_library.install_aliases()
 
 import contextlib
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -26,7 +27,7 @@ def tempdir():
     try:
         yield d
     finally:
-        os.rmdir(d)
+        shutil.rmtree(d)
 
 
 class TestDrawComputationalGraph(unittest.TestCase):

--- a/tests/misc_tests/test_draw_computational_graph.py
+++ b/tests/misc_tests/test_draw_computational_graph.py
@@ -18,19 +18,6 @@ import numpy as np
 import chainerrl
 
 
-@contextlib.contextmanager
-def tempdir():
-    """Alternative to tempfile.TemporaryDirectory.
-
-    tempfile.TemporaryDirectory is not available in Python 2.x.
-    """
-    d = tempfile.mkdtemp()
-    try:
-        yield d
-    finally:
-        shutil.rmtree(d)
-
-
 _v = chainer.Variable(np.zeros(5))
 _dav = chainerrl.action_value.DiscreteActionValue(
     chainer.Variable(np.zeros((5, 5))))
@@ -97,11 +84,11 @@ class TestDrawComputationalGraph(unittest.TestCase):
     def test_draw_computational_graph(self):
         x = chainer.Variable(np.zeros(5))
         y = x ** 2 + chainer.Variable(np.ones(5))
-        with tempdir() as d:
-            filepath = os.path.join(d, 'graph')
-            chainerrl.misc.draw_computational_graph(y, filepath)
-            self.assertTrue(os.path.exists(filepath + '.gv'))
-            if chainerrl.misc.is_graphviz_available():
-                self.assertTrue(os.path.exists(filepath + '.png'))
-            else:
-                self.assertFalse(os.path.exists(filepath + '.png'))
+        dirname = tempfile.mkdtemp()
+        filepath = os.path.join(dirname, 'graph')
+        chainerrl.misc.draw_computational_graph(y, filepath)
+        self.assertTrue(os.path.exists(filepath + '.gv'))
+        if chainerrl.misc.is_graphviz_available():
+            self.assertTrue(os.path.exists(filepath + '.png'))
+        else:
+            self.assertFalse(os.path.exists(filepath + '.png'))

--- a/tests/misc_tests/test_draw_computational_graph.py
+++ b/tests/misc_tests/test_draw_computational_graph.py
@@ -5,9 +5,7 @@ from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
-import contextlib
 import os
-import shutil
 import tempfile
 import unittest
 

--- a/tests/misc_tests/test_draw_computational_graph.py
+++ b/tests/misc_tests/test_draw_computational_graph.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
+import contextlib
 import os
 import tempfile
 import unittest
@@ -13,6 +14,19 @@ import chainer
 import numpy as np
 
 import chainerrl
+
+
+@contextlib.contextmanager
+def tempdir():
+    """Alternative to tempfile.TemporaryDirectory.
+
+    tempfile.TemporaryDirectory is not available in Python 2.x.
+    """
+    d = tempfile.mkdtemp()
+    try:
+        yield d
+    finally:
+        os.rmdir(d)
 
 
 class TestDrawComputationalGraph(unittest.TestCase):
@@ -78,7 +92,7 @@ class TestDrawComputationalGraph(unittest.TestCase):
     def test_draw_computational_graph(self):
         x = chainer.Variable(np.zeros(5))
         y = x ** 2 + chainer.Variable(np.ones(5))
-        with tempfile.TemporaryDirectory() as d:
+        with tempdir() as d:
             filepath = os.path.join(d, 'graph')
             chainerrl.misc.draw_computational_graph(y, filepath)
             self.assertTrue(os.path.exists(filepath + '.gv'))

--- a/tests/misc_tests/test_draw_computational_graph.py
+++ b/tests/misc_tests/test_draw_computational_graph.py
@@ -35,12 +35,12 @@ _gdis = chainerrl.distribution.GaussianDistribution(
     {'obj': [], 'expected': []},
     {'obj': (), 'expected': []},
     {'obj': _v, 'expected': [_v]},
-    {'obj': _dav, 'expected': [_dav.greedy_actions, _dav.max]},
-    {'obj': _qav, 'expected': [_qav.greedy_actions, _qav.max]},
+    {'obj': _dav, 'expected': list(_dav.params)},
+    {'obj': _qav, 'expected': list(_qav.params)},
     {'obj': _sdis, 'expected': list(_sdis.params)},
     {'obj': _gdis, 'expected': list(_gdis.params)},
-    {'obj': [_v, _dav, _sdis], 'expected': [
-        _v, _dav.greedy_actions, _dav.max] + list(_sdis.params)},
+    {'obj': [_v, _dav, _sdis],
+        'expected': [_v] + list(_dav.params) + list(_sdis.params)},
 )
 class TestCollectVariables(unittest.TestCase):
 

--- a/tests/misc_tests/test_is_return_code_zero.py
+++ b/tests/misc_tests/test_is_return_code_zero.py
@@ -1,0 +1,21 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+import unittest
+
+import chainerrl
+
+
+class TestIsReturnCodeZero(unittest.TestCase):
+
+    def test(self):
+        # Assume ls command exists
+        self.assertTrue(chainerrl.misc.is_return_code_zero(['ls']))
+        self.assertFalse(chainerrl.misc.is_return_code_zero(
+            ['ls --nonexistentoption']))
+        self.assertFalse(chainerrl.misc.is_return_code_zero(
+            ['nonexistentcommand']))

--- a/tests/test_action_value.py
+++ b/tests/test_action_value.py
@@ -59,3 +59,7 @@ class TestDiscreteActionValue(unittest.TestCase):
                 v = self.q_values[b, greedy_actions[b]]
                 adv = q - v
                 self.assertAlmostEqual(ret.data[b], adv)
+
+    def test_params(self):
+        self.assertEqual(len(self.qout.params), 1)
+        self.assertEqual(id(self.qout.params[0]), id(self.qout.q_values))


### PR DESCRIPTION
This PR adds `chainer.misc.draw_computational_graph` to help draw computational graphs of RL models as PNG images.

I'm not sure if I should draw a graph in every example, but it would be a good habit. For this PR I just add such code only in `examples/gym/train_reinforce_gym.py`