### PR TITLE
Improve StateActionQFunctions

### DIFF
--- a/chainerrl/q_functions/state_action_q_functions.py
+++ b/chainerrl/q_functions/state_action_q_functions.py
@@ -42,7 +42,10 @@ class FCSAQFunction(MLP, StateActionQFunction):
         n_dim_action (int): Number of dimensions of action space.
         n_hidden_channels (int): Number of hidden channels.
         n_hidden_layers (int): Number of hidden layers.
-        nonlinearity (callable): Nonlinearity between layers.
+        nonlinearity (callable): Nonlinearity between layers. It must accept a
+            Variable as an argument and return a Variable with the same shape.
+            Nonlinearities with learnable parameters such as PReLU are not
+            supported.
         last_wscale (float): Scale of weight initialization of the last layer.
     """
 
@@ -75,7 +78,10 @@ class FCLSTMSAQFunction(chainer.Chain, StateActionQFunction,
         n_dim_action (int): Number of dimensions of action space.
         n_hidden_channels (int): Number of hidden channels.
         n_hidden_layers (int): Number of hidden layers.
-        nonlinearity (callable): Nonlinearity between layers.
+        nonlinearity (callable): Nonlinearity between layers. It must accept a
+            Variable as an argument and return a Variable with the same shape.
+            Nonlinearities with learnable parameters such as PReLU are not
+            supported.
         last_wscale (float): Scale of weight initialization of the last layer.
     """
 
@@ -112,7 +118,10 @@ class FCBNSAQFunction(MLPBN, StateActionQFunction):
         n_hidden_layers (int): Number of hidden layers.
         normalize_input (bool): If set to True, Batch Normalization is applied
             to both observations and actions.
-        nonlinearity (callable): Nonlinearity between layers.
+        nonlinearity (callable): Nonlinearity between layers. It must accept a
+            Variable as an argument and return a Variable with the same shape.
+            Nonlinearities with learnable parameters such as PReLU are not
+            supported.
         last_wscale (float): Scale of weight initialization of the last layer.
     """
 
@@ -151,7 +160,10 @@ class FCBNLateActionSAQFunction(chainer.Chain, StateActionQFunction,
         n_hidden_channels (int): Number of hidden channels.
         n_hidden_layers (int): Number of hidden layers.
         normalize_input (bool): If set to True, Batch Normalization is applied
-        nonlinearity (callable): Nonlinearity between layers.
+        nonlinearity (callable): Nonlinearity between layers. It must accept a
+            Variable as an argument and return a Variable with the same shape.
+            Nonlinearities with learnable parameters such as PReLU are not
+            supported.
         last_wscale (float): Scale of weight initialization of the last layer.
 
     """
@@ -200,7 +212,10 @@ class FCLateActionSAQFunction(chainer.Chain, StateActionQFunction,
         n_dim_action (int): Number of dimensions of action space.
         n_hidden_channels (int): Number of hidden channels.
         n_hidden_layers (int): Number of hidden layers.
-        nonlinearity (callable): Nonlinearity between layers.
+        nonlinearity (callable): Nonlinearity between layers. It must accept a
+            Variable as an argument and return a Variable with the same shape.
+            Nonlinearities with learnable parameters such as PReLU are not
+            supported.
         last_wscale (float): Scale of weight initialization of the last layer.
     """
 

--- a/chainerrl/q_functions/state_action_q_functions.py
+++ b/chainerrl/q_functions/state_action_q_functions.py
@@ -158,19 +158,20 @@ class FCBNLateActionSAQFunction(chainer.Chain, StateActionQFunction,
         n_dim_obs (int): Number of dimensions of observation space.
         n_dim_action (int): Number of dimensions of action space.
         n_hidden_channels (int): Number of hidden channels.
-        n_hidden_layers (int): Number of hidden layers.
+        n_hidden_layers (int): Number of hidden layers. It must be greater than
+            or equal to 1.
         normalize_input (bool): If set to True, Batch Normalization is applied
         nonlinearity (callable): Nonlinearity between layers. It must accept a
             Variable as an argument and return a Variable with the same shape.
             Nonlinearities with learnable parameters such as PReLU are not
             supported.
         last_wscale (float): Scale of weight initialization of the last layer.
-
     """
 
     def __init__(self, n_dim_obs, n_dim_action, n_hidden_channels,
                  n_hidden_layers, normalize_input=True,
                  nonlinearity=F.relu, last_wscale=1.):
+        assert n_hidden_layers >= 1
         self.n_input_channels = n_dim_obs + n_dim_action
         self.n_hidden_layers = n_hidden_layers
         self.n_hidden_channels = n_hidden_channels
@@ -211,7 +212,8 @@ class FCLateActionSAQFunction(chainer.Chain, StateActionQFunction,
         n_dim_obs (int): Number of dimensions of observation space.
         n_dim_action (int): Number of dimensions of action space.
         n_hidden_channels (int): Number of hidden channels.
-        n_hidden_layers (int): Number of hidden layers.
+        n_hidden_layers (int): Number of hidden layers. It must be greater than
+            or equal to 1.
         nonlinearity (callable): Nonlinearity between layers. It must accept a
             Variable as an argument and return a Variable with the same shape.
             Nonlinearities with learnable parameters such as PReLU are not
@@ -221,6 +223,7 @@ class FCLateActionSAQFunction(chainer.Chain, StateActionQFunction,
 
     def __init__(self, n_dim_obs, n_dim_action, n_hidden_channels,
                  n_hidden_layers, nonlinearity=F.relu, last_wscale=1.):
+        assert n_hidden_layers >= 1
         self.n_input_channels = n_dim_obs + n_dim_action
         self.n_hidden_layers = n_hidden_layers
         self.n_hidden_channels = n_hidden_channels

--- a/chainerrl/q_functions/state_action_q_functions.py
+++ b/chainerrl/q_functions/state_action_q_functions.py
@@ -34,94 +34,103 @@ class SingleModelStateActionQFunction(
         return h
 
 
-class FCSAQFunction(chainer.ChainList, StateActionQFunction):
-    """Fully-connected (s,a)-input continuous Q-function.
+class FCSAQFunction(MLP, StateActionQFunction):
+    """Fully-connected (s,a)-input Q-function.
 
     Args:
-        n_dim_obs: number of dimensions of observation space
-        n_dim_action: number of dimensions of action space
-        n_hidden_channels: number of hidden channels
-        n_hidden_layers: number of hidden layers
+        n_dim_obs (int): Number of dimensions of observation space.
+        n_dim_action (int): Number of dimensions of action space.
+        n_hidden_channels (int): Number of hidden channels.
+        n_hidden_layers (int): Number of hidden layers.
+        nonlinearity (callable): Nonlinearity between layers.
+        last_wscale (float): Scale of weight initialization of the last layer.
     """
 
     def __init__(self, n_dim_obs, n_dim_action, n_hidden_channels,
                  n_hidden_layers, nonlinearity=F.relu,
-                 last_wscale=1):
+                 last_wscale=1.):
         self.n_input_channels = n_dim_obs + n_dim_action
         self.n_hidden_layers = n_hidden_layers
         self.n_hidden_channels = n_hidden_channels
         self.nonlinearity = nonlinearity
-
-        layers = []
-        assert self.n_hidden_layers >= 1
-        layers.append(
-            L.Linear(self.n_input_channels, self.n_hidden_channels))
-        for i in range(self.n_hidden_layers - 1):
-            layers.append(
-                L.Linear(self.n_hidden_channels, self.n_hidden_channels))
-        layers.append(L.Linear(self.n_hidden_channels, 1,
-                               initialW=LeCunNormal(last_wscale)))
-        super().__init__(*layers)
-        self.output = layers[-1]
+        super().__init__(
+            in_size=self.n_input_channels,
+            out_size=1,
+            hidden_sizes=[self.n_hidden_channels] * self.n_hidden_layers,
+            nonlinearity=nonlinearity,
+            last_wscale=last_wscale,
+        )
 
     def __call__(self, state, action):
         h = F.concat((state, action), axis=1)
-        for layer in self[:-1]:
-            h = self.nonlinearity(layer(h))
-        h = self[-1](h)
-        return h
+        return super().__call__(h)
 
 
 class FCLSTMSAQFunction(chainer.Chain, StateActionQFunction,
                         RecurrentChainMixin):
-    """Fully-connected (s,a)-input continuous Q-function.
+    """Fully-connected + LSTM (s,a)-input Q-function.
 
     Args:
-        n_dim_obs: number of dimensions of observation space
-        n_dim_action: number of dimensions of action space
-        n_hidden_channels: number of hidden channels
-        n_hidden_layers: number of hidden layers
+        n_dim_obs (int): Number of dimensions of observation space.
+        n_dim_action (int): Number of dimensions of action space.
+        n_hidden_channels (int): Number of hidden channels.
+        n_hidden_layers (int): Number of hidden layers.
+        nonlinearity (callable): Nonlinearity between layers.
+        last_wscale (float): Scale of weight initialization of the last layer.
     """
 
     def __init__(self, n_dim_obs, n_dim_action, n_hidden_channels,
-                 n_hidden_layers):
+                 n_hidden_layers, nonlinearity=F.relu, last_wscale=1.):
         self.n_input_channels = n_dim_obs + n_dim_action
         self.n_hidden_layers = n_hidden_layers
         self.n_hidden_channels = n_hidden_channels
+        self.nonlinearity = nonlinearity
         super().__init__()
         with self.init_scope():
             self.fc = MLP(self.n_input_channels, n_hidden_channels,
-                          [self.n_hidden_channels] * self.n_hidden_layers)
+                          [self.n_hidden_channels] * self.n_hidden_layers,
+                          nonlinearity=nonlinearity,
+                          )
             self.lstm = L.LSTM(n_hidden_channels, n_hidden_channels)
-            self.out = L.Linear(n_hidden_channels, 1)
+            self.out = L.Linear(n_hidden_channels, 1,
+                                initialW=LeCunNormal(last_wscale))
 
     def __call__(self, x, a):
         h = F.concat((x, a), axis=1)
-        h = F.relu(self.fc(h))
+        h = self.nonlinearity(self.fc(h))
         h = self.lstm(h)
         return self.out(h)
 
 
 class FCBNSAQFunction(MLPBN, StateActionQFunction):
-    """Fully-connected (s,a)-input continuous Q-function.
+    """Fully-connected + BN (s,a)-input Q-function.
 
     Args:
-        n_dim_obs: number of dimensions of observation space
-        n_dim_action: number of dimensions of action space
-        n_hidden_channels: number of hidden channels
-        n_hidden_layers: number of hidden layers
+        n_dim_obs (int): Number of dimensions of observation space.
+        n_dim_action (int): Number of dimensions of action space.
+        n_hidden_channels (int): Number of hidden channels.
+        n_hidden_layers (int): Number of hidden layers.
+        normalize_input (bool): If set to True, Batch Normalization is applied
+            to both observations and actions.
+        nonlinearity (callable): Nonlinearity between layers.
+        last_wscale (float): Scale of weight initialization of the last layer.
     """
 
     def __init__(self, n_dim_obs, n_dim_action, n_hidden_channels,
-                 n_hidden_layers, normalize_input=True):
+                 n_hidden_layers, normalize_input=True,
+                 nonlinearity=F.relu, last_wscale=1.):
         self.n_input_channels = n_dim_obs + n_dim_action
         self.n_hidden_layers = n_hidden_layers
         self.n_hidden_channels = n_hidden_channels
         self.normalize_input = normalize_input
+        self.nonlinearity = nonlinearity
         super().__init__(
             in_size=self.n_input_channels, out_size=1,
             hidden_sizes=[self.n_hidden_channels] * self.n_hidden_layers,
-            normalize_input=self.normalize_input)
+            normalize_input=self.normalize_input,
+            nonlinearity=nonlinearity,
+            last_wscale=last_wscale,
+        )
 
     def __call__(self, state, action):
         h = F.concat((state, action), axis=1)
@@ -130,25 +139,31 @@ class FCBNSAQFunction(MLPBN, StateActionQFunction):
 
 class FCBNLateActionSAQFunction(chainer.Chain, StateActionQFunction,
                                 RecurrentChainMixin):
-    """Fully-connected (s,a)-input continuous Q-function.
+    """Fully-connected + BN (s,a)-input Q-function with late action input.
 
     Actions are not included until the second hidden layer and not normalized.
     This architecture is used in the DDPG paper:
     http://arxiv.org/abs/1509.02971
 
     Args:
-        n_dim_obs: number of dimensions of observation space
-        n_dim_action: number of dimensions of action space
-        n_hidden_channels: number of hidden channels
-        n_hidden_layers: number of hidden layers
+        n_dim_obs (int): Number of dimensions of observation space.
+        n_dim_action (int): Number of dimensions of action space.
+        n_hidden_channels (int): Number of hidden channels.
+        n_hidden_layers (int): Number of hidden layers.
+        normalize_input (bool): If set to True, Batch Normalization is applied
+        nonlinearity (callable): Nonlinearity between layers.
+        last_wscale (float): Scale of weight initialization of the last layer.
+
     """
 
     def __init__(self, n_dim_obs, n_dim_action, n_hidden_channels,
-                 n_hidden_layers, normalize_input=True):
+                 n_hidden_layers, normalize_input=True,
+                 nonlinearity=F.relu, last_wscale=1.):
         self.n_input_channels = n_dim_obs + n_dim_action
         self.n_hidden_layers = n_hidden_layers
         self.n_hidden_channels = n_hidden_channels
         self.normalize_input = normalize_input
+        self.nonlinearity = nonlinearity
 
         super().__init__()
         with self.init_scope():
@@ -159,36 +174,42 @@ class FCBNLateActionSAQFunction(chainer.Chain, StateActionQFunction,
             self.mlp = MLP(in_size=n_hidden_channels + n_dim_action,
                            out_size=1,
                            hidden_sizes=([self.n_hidden_channels] *
-                                         (self.n_hidden_layers - 1)))
+                                         (self.n_hidden_layers - 1)),
+                           nonlinearity=nonlinearity,
+                           last_wscale=last_wscale,
+                           )
 
         self.output = self.mlp.output
 
     def __call__(self, state, action):
-        h = F.relu(self.obs_mlp(state))
+        h = self.nonlinearity(self.obs_mlp(state))
         h = F.concat((h, action), axis=1)
         return self.mlp(h)
 
 
 class FCLateActionSAQFunction(chainer.Chain, StateActionQFunction,
                               RecurrentChainMixin):
-    """Fully-connected (s,a)-input continuous Q-function.
+    """Fully-connected (s,a)-input Q-function with late action input.
 
     Actions are not included until the second hidden layer and not normalized.
     This architecture is used in the DDPG paper:
     http://arxiv.org/abs/1509.02971
 
     Args:
-        n_dim_obs: number of dimensions of observation space
-        n_dim_action: number of dimensions of action space
-        n_hidden_channels: number of hidden channels
-        n_hidden_layers: number of hidden layers
+        n_dim_obs (int): Number of dimensions of observation space.
+        n_dim_action (int): Number of dimensions of action space.
+        n_hidden_channels (int): Number of hidden channels.
+        n_hidden_layers (int): Number of hidden layers.
+        nonlinearity (callable): Nonlinearity between layers.
+        last_wscale (float): Scale of weight initialization of the last layer.
     """
 
     def __init__(self, n_dim_obs, n_dim_action, n_hidden_channels,
-                 n_hidden_layers):
+                 n_hidden_layers, nonlinearity=F.relu, last_wscale=1.):
         self.n_input_channels = n_dim_obs + n_dim_action
         self.n_hidden_layers = n_hidden_layers
         self.n_hidden_channels = n_hidden_channels
+        self.nonlinearity = nonlinearity
 
         super().__init__()
         with self.init_scope():
@@ -197,11 +218,14 @@ class FCLateActionSAQFunction(chainer.Chain, StateActionQFunction,
             self.mlp = MLP(in_size=n_hidden_channels + n_dim_action,
                            out_size=1,
                            hidden_sizes=([self.n_hidden_channels] *
-                                         (self.n_hidden_layers - 1)))
+                                         (self.n_hidden_layers - 1)),
+                           nonlinearity=nonlinearity,
+                           last_wscale=last_wscale,
+                           )
 
         self.output = self.mlp.output
 
     def __call__(self, state, action):
-        h = F.relu(self.obs_mlp(state))
+        h = self.nonlinearity(self.obs_mlp(state))
         h = F.concat((h, action), axis=1)
         return self.mlp(h)

--- a/chainerrl/q_functions/state_action_q_functions.py
+++ b/chainerrl/q_functions/state_action_q_functions.py
@@ -45,7 +45,7 @@ class FCSAQFunction(MLP, StateActionQFunction):
         nonlinearity (callable): Nonlinearity between layers. It must accept a
             Variable as an argument and return a Variable with the same shape.
             Nonlinearities with learnable parameters such as PReLU are not
-            supported.
+            supported. It is not used if n_hidden_layers is zero.
         last_wscale (float): Scale of weight initialization of the last layer.
     """
 
@@ -121,7 +121,7 @@ class FCBNSAQFunction(MLPBN, StateActionQFunction):
         nonlinearity (callable): Nonlinearity between layers. It must accept a
             Variable as an argument and return a Variable with the same shape.
             Nonlinearities with learnable parameters such as PReLU are not
-            supported.
+            supported. It is not used if n_hidden_layers is zero.
         last_wscale (float): Scale of weight initialization of the last layer.
     """
 

--- a/chainerrl/q_functions/state_action_q_functions.py
+++ b/chainerrl/q_functions/state_action_q_functions.py
@@ -180,6 +180,8 @@ class FCBNLateActionSAQFunction(chainer.Chain, StateActionQFunction,
 
         super().__init__()
         with self.init_scope():
+            # No need to pass nonlinearity to obs_mlp because it has no
+            # hidden layers
             self.obs_mlp = MLPBN(in_size=n_dim_obs, out_size=n_hidden_channels,
                                  hidden_sizes=[],
                                  normalize_input=normalize_input,
@@ -231,6 +233,8 @@ class FCLateActionSAQFunction(chainer.Chain, StateActionQFunction,
 
         super().__init__()
         with self.init_scope():
+            # No need to pass nonlinearity to obs_mlp because it has no
+            # hidden layers
             self.obs_mlp = MLP(in_size=n_dim_obs, out_size=n_hidden_channels,
                                hidden_sizes=[])
             self.mlp = MLP(in_size=n_hidden_channels + n_dim_action,

--- a/tests/q_functions_tests/test_state_action_q_function.py
+++ b/tests/q_functions_tests/test_state_action_q_function.py
@@ -8,12 +8,11 @@ standard_library.install_aliases()
 
 import unittest
 
-import numpy as np
-
 import chainer
 import chainer.functions as F
 from chainer import testing
 from chainer.testing import attr
+import numpy as np
 
 import chainerrl
 

--- a/tests/q_functions_tests/test_state_action_q_function.py
+++ b/tests/q_functions_tests/test_state_action_q_function.py
@@ -1,0 +1,242 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()
+
+import unittest
+
+import numpy as np
+
+import chainer
+import chainer.functions as F
+from chainer import testing
+from chainer.testing import attr
+
+import chainerrl
+
+
+@testing.parameterize(
+    *testing.product({
+        'n_dim_obs': [1, 5],
+        'n_dim_action': [1, 3],
+        'n_hidden_layers': [0, 1, 2],
+        'n_hidden_channels': [1, 2],
+        'nonlinearity': ['relu', 'elu'],
+        'last_wscale': [1, 1e-3],
+    })
+)
+class TestFCSAQFunction(unittest.TestCase):
+
+    def _test_call(self, gpu):
+        nonlinearity = getattr(F, self.nonlinearity)
+        qf = chainerrl.q_functions.FCSAQFunction(
+            n_dim_obs=self.n_dim_obs,
+            n_dim_action=self.n_dim_action,
+            n_hidden_layers=self.n_hidden_layers,
+            n_hidden_channels=self.n_hidden_channels,
+            nonlinearity=nonlinearity,
+            last_wscale=self.last_wscale,
+        )
+        batch_size = 7
+        obs = np.random.rand(batch_size, self.n_dim_obs).astype(np.float32)
+        action = np.random.rand(
+            batch_size, self.n_dim_action).astype(np.float32)
+        if gpu >= 0:
+            qf.to_gpu(gpu)
+            obs = chainer.cuda.to_gpu(obs)
+            action = chainer.cuda.to_gpu(action)
+        y = qf(obs, action)
+        self.assertTrue(isinstance(y, chainer.Variable))
+        self.assertEqual(y.shape, (batch_size, 1))
+        self.assertEqual(chainer.cuda.get_array_module(y),
+                         chainer.cuda.get_array_module(obs))
+
+    def test_call_cpu(self):
+        self._test_call(gpu=-1)
+
+    @attr.gpu
+    def test_call_gpu(self):
+        self._test_call(gpu=0)
+
+
+@testing.parameterize(
+    *testing.product({
+        'n_dim_obs': [1, 5],
+        'n_dim_action': [1, 3],
+        'n_hidden_layers': [0, 1, 2],
+        'n_hidden_channels': [1, 2],
+        'nonlinearity': ['relu', 'elu'],
+        'last_wscale': [1, 1e-3],
+    })
+)
+class TestFCLSTMSAQFunction(unittest.TestCase):
+
+    def _test_call(self, gpu):
+        nonlinearity = getattr(F, self.nonlinearity)
+        qf = chainerrl.q_functions.FCLSTMSAQFunction(
+            n_dim_obs=self.n_dim_obs,
+            n_dim_action=self.n_dim_action,
+            n_hidden_layers=self.n_hidden_layers,
+            n_hidden_channels=self.n_hidden_channels,
+            nonlinearity=nonlinearity,
+            last_wscale=self.last_wscale,
+        )
+        batch_size = 7
+        obs = np.random.rand(batch_size, self.n_dim_obs).astype(np.float32)
+        action = np.random.rand(
+            batch_size, self.n_dim_action).astype(np.float32)
+        if gpu >= 0:
+            qf.to_gpu(gpu)
+            obs = chainer.cuda.to_gpu(obs)
+            action = chainer.cuda.to_gpu(action)
+        y = qf(obs, action)
+        self.assertTrue(isinstance(y, chainer.Variable))
+        self.assertEqual(y.shape, (batch_size, 1))
+        self.assertEqual(chainer.cuda.get_array_module(y),
+                         chainer.cuda.get_array_module(obs))
+
+    def test_call_cpu(self):
+        self._test_call(gpu=-1)
+
+    @attr.gpu
+    def test_call_gpu(self):
+        self._test_call(gpu=0)
+
+
+@testing.parameterize(
+    *testing.product({
+        'n_dim_obs': [1, 5],
+        'n_dim_action': [1, 3],
+        'n_hidden_layers': [0, 1, 2],
+        'n_hidden_channels': [1, 2],
+        'normalize_input': [True, False],
+        'nonlinearity': ['relu', 'elu'],
+        'last_wscale': [1, 1e-3],
+    })
+)
+class TestFCBNSAQFunction(unittest.TestCase):
+
+    def _test_call(self, gpu):
+        nonlinearity = getattr(F, self.nonlinearity)
+        qf = chainerrl.q_functions.FCBNSAQFunction(
+            n_dim_obs=self.n_dim_obs,
+            n_dim_action=self.n_dim_action,
+            n_hidden_layers=self.n_hidden_layers,
+            n_hidden_channels=self.n_hidden_channels,
+            normalize_input=self.normalize_input,
+            nonlinearity=nonlinearity,
+            last_wscale=self.last_wscale,
+        )
+        batch_size = 7
+        obs = np.random.rand(batch_size, self.n_dim_obs).astype(np.float32)
+        action = np.random.rand(
+            batch_size, self.n_dim_action).astype(np.float32)
+        if gpu >= 0:
+            qf.to_gpu(gpu)
+            obs = chainer.cuda.to_gpu(obs)
+            action = chainer.cuda.to_gpu(action)
+        y = qf(obs, action)
+        self.assertTrue(isinstance(y, chainer.Variable))
+        self.assertEqual(y.shape, (batch_size, 1))
+        self.assertEqual(chainer.cuda.get_array_module(y),
+                         chainer.cuda.get_array_module(obs))
+
+    def test_call_cpu(self):
+        self._test_call(gpu=-1)
+
+    @attr.gpu
+    def test_call_gpu(self):
+        self._test_call(gpu=0)
+
+
+@testing.parameterize(
+    *testing.product({
+        'n_dim_obs': [1, 5],
+        'n_dim_action': [1, 3],
+        'n_hidden_layers': [0, 1, 2],
+        'n_hidden_channels': [1, 2],
+        'normalize_input': [True, False],
+        'nonlinearity': ['relu', 'elu'],
+        'last_wscale': [1, 1e-3],
+    })
+)
+class TestFCBNLateActionSAQFunction(unittest.TestCase):
+
+    def _test_call(self, gpu):
+        nonlinearity = getattr(F, self.nonlinearity)
+        qf = chainerrl.q_functions.FCBNLateActionSAQFunction(
+            n_dim_obs=self.n_dim_obs,
+            n_dim_action=self.n_dim_action,
+            n_hidden_layers=self.n_hidden_layers,
+            n_hidden_channels=self.n_hidden_channels,
+            normalize_input=self.normalize_input,
+            nonlinearity=nonlinearity,
+            last_wscale=self.last_wscale,
+        )
+        batch_size = 7
+        obs = np.random.rand(batch_size, self.n_dim_obs).astype(np.float32)
+        action = np.random.rand(
+            batch_size, self.n_dim_action).astype(np.float32)
+        if gpu >= 0:
+            qf.to_gpu(gpu)
+            obs = chainer.cuda.to_gpu(obs)
+            action = chainer.cuda.to_gpu(action)
+        y = qf(obs, action)
+        self.assertTrue(isinstance(y, chainer.Variable))
+        self.assertEqual(y.shape, (batch_size, 1))
+        self.assertEqual(chainer.cuda.get_array_module(y),
+                         chainer.cuda.get_array_module(obs))
+
+    def test_call_cpu(self):
+        self._test_call(gpu=-1)
+
+    @attr.gpu
+    def test_call_gpu(self):
+        self._test_call(gpu=0)
+
+
+@testing.parameterize(
+    *testing.product({
+        'n_dim_obs': [1, 5],
+        'n_dim_action': [1, 3],
+        'n_hidden_layers': [0, 1, 2],
+        'n_hidden_channels': [1, 2],
+        'nonlinearity': ['relu', 'elu'],
+        'last_wscale': [1, 1e-3],
+    })
+)
+class TestFCLateActionSAQFunction(unittest.TestCase):
+
+    def _test_call(self, gpu):
+        nonlinearity = getattr(F, self.nonlinearity)
+        qf = chainerrl.q_functions.FCLateActionSAQFunction(
+            n_dim_obs=self.n_dim_obs,
+            n_dim_action=self.n_dim_action,
+            n_hidden_layers=self.n_hidden_layers,
+            n_hidden_channels=self.n_hidden_channels,
+            nonlinearity=nonlinearity,
+            last_wscale=self.last_wscale,
+        )
+        batch_size = 7
+        obs = np.random.rand(batch_size, self.n_dim_obs).astype(np.float32)
+        action = np.random.rand(
+            batch_size, self.n_dim_action).astype(np.float32)
+        if gpu >= 0:
+            qf.to_gpu(gpu)
+            obs = chainer.cuda.to_gpu(obs)
+            action = chainer.cuda.to_gpu(action)
+        y = qf(obs, action)
+        self.assertTrue(isinstance(y, chainer.Variable))
+        self.assertEqual(y.shape, (batch_size, 1))
+        self.assertEqual(chainer.cuda.get_array_module(y),
+                         chainer.cuda.get_array_module(obs))
+
+    def test_call_cpu(self):
+        self._test_call(gpu=-1)
+
+    @attr.gpu
+    def test_call_gpu(self):
+        self._test_call(gpu=0)

--- a/tests/q_functions_tests/test_state_action_q_function.py
+++ b/tests/q_functions_tests/test_state_action_q_function.py
@@ -139,7 +139,7 @@ class TestFCBNSAQFunction(_TestSAQFunction):
     *testing.product({
         'n_dim_obs': [1, 5],
         'n_dim_action': [1, 3],
-        'n_hidden_layers': [0, 1, 2],
+        'n_hidden_layers': [1, 2],  # LateAction requires n_hidden_layers >=1
         'n_hidden_channels': [1, 2],
         'normalize_input': [True, False],
         'nonlinearity': ['relu', 'elu'],
@@ -173,7 +173,7 @@ class TestFCBNLateActionSAQFunction(_TestSAQFunction):
     *testing.product({
         'n_dim_obs': [1, 5],
         'n_dim_action': [1, 3],
-        'n_hidden_layers': [0, 1, 2],
+        'n_hidden_layers': [1, 2],  # LateAction requires n_hidden_layers >=1
         'n_hidden_channels': [1, 2],
         'nonlinearity': ['relu', 'elu'],
         'last_wscale': [1, 1e-3],

--- a/tests/q_functions_tests/test_state_action_q_function.py
+++ b/tests/q_functions_tests/test_state_action_q_function.py
@@ -18,6 +18,26 @@ from chainer.testing import attr
 import chainerrl
 
 
+class _TestSAQFunction(unittest.TestCase):
+
+    def _test_call_given_model(self, model, gpu):
+        # This method only check if a given model can receive random input
+        # data and return output data with the correct interface.
+        batch_size = 7
+        obs = np.random.rand(batch_size, self.n_dim_obs).astype(np.float32)
+        action = np.random.rand(
+            batch_size, self.n_dim_action).astype(np.float32)
+        if gpu >= 0:
+            model.to_gpu(gpu)
+            obs = chainer.cuda.to_gpu(obs)
+            action = chainer.cuda.to_gpu(action)
+        y = model(obs, action)
+        self.assertTrue(isinstance(y, chainer.Variable))
+        self.assertEqual(y.shape, (batch_size, 1))
+        self.assertEqual(chainer.cuda.get_array_module(y),
+                         chainer.cuda.get_array_module(obs))
+
+
 @testing.parameterize(
     *testing.product({
         'n_dim_obs': [1, 5],
@@ -28,11 +48,11 @@ import chainerrl
         'last_wscale': [1, 1e-3],
     })
 )
-class TestFCSAQFunction(unittest.TestCase):
+class TestFCSAQFunction(_TestSAQFunction):
 
     def _test_call(self, gpu):
         nonlinearity = getattr(F, self.nonlinearity)
-        qf = chainerrl.q_functions.FCSAQFunction(
+        model = chainerrl.q_functions.FCSAQFunction(
             n_dim_obs=self.n_dim_obs,
             n_dim_action=self.n_dim_action,
             n_hidden_layers=self.n_hidden_layers,
@@ -40,19 +60,7 @@ class TestFCSAQFunction(unittest.TestCase):
             nonlinearity=nonlinearity,
             last_wscale=self.last_wscale,
         )
-        batch_size = 7
-        obs = np.random.rand(batch_size, self.n_dim_obs).astype(np.float32)
-        action = np.random.rand(
-            batch_size, self.n_dim_action).astype(np.float32)
-        if gpu >= 0:
-            qf.to_gpu(gpu)
-            obs = chainer.cuda.to_gpu(obs)
-            action = chainer.cuda.to_gpu(action)
-        y = qf(obs, action)
-        self.assertTrue(isinstance(y, chainer.Variable))
-        self.assertEqual(y.shape, (batch_size, 1))
-        self.assertEqual(chainer.cuda.get_array_module(y),
-                         chainer.cuda.get_array_module(obs))
+        self._test_call_given_model(model, gpu)
 
     def test_call_cpu(self):
         self._test_call(gpu=-1)
@@ -72,11 +80,11 @@ class TestFCSAQFunction(unittest.TestCase):
         'last_wscale': [1, 1e-3],
     })
 )
-class TestFCLSTMSAQFunction(unittest.TestCase):
+class TestFCLSTMSAQFunction(_TestSAQFunction):
 
     def _test_call(self, gpu):
         nonlinearity = getattr(F, self.nonlinearity)
-        qf = chainerrl.q_functions.FCLSTMSAQFunction(
+        model = chainerrl.q_functions.FCLSTMSAQFunction(
             n_dim_obs=self.n_dim_obs,
             n_dim_action=self.n_dim_action,
             n_hidden_layers=self.n_hidden_layers,
@@ -84,65 +92,7 @@ class TestFCLSTMSAQFunction(unittest.TestCase):
             nonlinearity=nonlinearity,
             last_wscale=self.last_wscale,
         )
-        batch_size = 7
-        obs = np.random.rand(batch_size, self.n_dim_obs).astype(np.float32)
-        action = np.random.rand(
-            batch_size, self.n_dim_action).astype(np.float32)
-        if gpu >= 0:
-            qf.to_gpu(gpu)
-            obs = chainer.cuda.to_gpu(obs)
-            action = chainer.cuda.to_gpu(action)
-        y = qf(obs, action)
-        self.assertTrue(isinstance(y, chainer.Variable))
-        self.assertEqual(y.shape, (batch_size, 1))
-        self.assertEqual(chainer.cuda.get_array_module(y),
-                         chainer.cuda.get_array_module(obs))
-
-    def test_call_cpu(self):
-        self._test_call(gpu=-1)
-
-    @attr.gpu
-    def test_call_gpu(self):
-        self._test_call(gpu=0)
-
-
-@testing.parameterize(
-    *testing.product({
-        'n_dim_obs': [1, 5],
-        'n_dim_action': [1, 3],
-        'n_hidden_layers': [0, 1, 2],
-        'n_hidden_channels': [1, 2],
-        'normalize_input': [True, False],
-        'nonlinearity': ['relu', 'elu'],
-        'last_wscale': [1, 1e-3],
-    })
-)
-class TestFCBNSAQFunction(unittest.TestCase):
-
-    def _test_call(self, gpu):
-        nonlinearity = getattr(F, self.nonlinearity)
-        qf = chainerrl.q_functions.FCBNSAQFunction(
-            n_dim_obs=self.n_dim_obs,
-            n_dim_action=self.n_dim_action,
-            n_hidden_layers=self.n_hidden_layers,
-            n_hidden_channels=self.n_hidden_channels,
-            normalize_input=self.normalize_input,
-            nonlinearity=nonlinearity,
-            last_wscale=self.last_wscale,
-        )
-        batch_size = 7
-        obs = np.random.rand(batch_size, self.n_dim_obs).astype(np.float32)
-        action = np.random.rand(
-            batch_size, self.n_dim_action).astype(np.float32)
-        if gpu >= 0:
-            qf.to_gpu(gpu)
-            obs = chainer.cuda.to_gpu(obs)
-            action = chainer.cuda.to_gpu(action)
-        y = qf(obs, action)
-        self.assertTrue(isinstance(y, chainer.Variable))
-        self.assertEqual(y.shape, (batch_size, 1))
-        self.assertEqual(chainer.cuda.get_array_module(y),
-                         chainer.cuda.get_array_module(obs))
+        self._test_call_given_model(model, gpu)
 
     def test_call_cpu(self):
         self._test_call(gpu=-1)
@@ -163,11 +113,11 @@ class TestFCBNSAQFunction(unittest.TestCase):
         'last_wscale': [1, 1e-3],
     })
 )
-class TestFCBNLateActionSAQFunction(unittest.TestCase):
+class TestFCBNSAQFunction(_TestSAQFunction):
 
     def _test_call(self, gpu):
         nonlinearity = getattr(F, self.nonlinearity)
-        qf = chainerrl.q_functions.FCBNLateActionSAQFunction(
+        model = chainerrl.q_functions.FCBNSAQFunction(
             n_dim_obs=self.n_dim_obs,
             n_dim_action=self.n_dim_action,
             n_hidden_layers=self.n_hidden_layers,
@@ -176,19 +126,41 @@ class TestFCBNLateActionSAQFunction(unittest.TestCase):
             nonlinearity=nonlinearity,
             last_wscale=self.last_wscale,
         )
-        batch_size = 7
-        obs = np.random.rand(batch_size, self.n_dim_obs).astype(np.float32)
-        action = np.random.rand(
-            batch_size, self.n_dim_action).astype(np.float32)
-        if gpu >= 0:
-            qf.to_gpu(gpu)
-            obs = chainer.cuda.to_gpu(obs)
-            action = chainer.cuda.to_gpu(action)
-        y = qf(obs, action)
-        self.assertTrue(isinstance(y, chainer.Variable))
-        self.assertEqual(y.shape, (batch_size, 1))
-        self.assertEqual(chainer.cuda.get_array_module(y),
-                         chainer.cuda.get_array_module(obs))
+        self._test_call_given_model(model, gpu)
+
+    def test_call_cpu(self):
+        self._test_call(gpu=-1)
+
+    @attr.gpu
+    def test_call_gpu(self):
+        self._test_call(gpu=0)
+
+
+@testing.parameterize(
+    *testing.product({
+        'n_dim_obs': [1, 5],
+        'n_dim_action': [1, 3],
+        'n_hidden_layers': [0, 1, 2],
+        'n_hidden_channels': [1, 2],
+        'normalize_input': [True, False],
+        'nonlinearity': ['relu', 'elu'],
+        'last_wscale': [1, 1e-3],
+    })
+)
+class TestFCBNLateActionSAQFunction(_TestSAQFunction):
+
+    def _test_call(self, gpu):
+        nonlinearity = getattr(F, self.nonlinearity)
+        model = chainerrl.q_functions.FCBNLateActionSAQFunction(
+            n_dim_obs=self.n_dim_obs,
+            n_dim_action=self.n_dim_action,
+            n_hidden_layers=self.n_hidden_layers,
+            n_hidden_channels=self.n_hidden_channels,
+            normalize_input=self.normalize_input,
+            nonlinearity=nonlinearity,
+            last_wscale=self.last_wscale,
+        )
+        self._test_call_given_model(model, gpu)
 
     def test_call_cpu(self):
         self._test_call(gpu=-1)
@@ -208,11 +180,11 @@ class TestFCBNLateActionSAQFunction(unittest.TestCase):
         'last_wscale': [1, 1e-3],
     })
 )
-class TestFCLateActionSAQFunction(unittest.TestCase):
+class TestFCLateActionSAQFunction(_TestSAQFunction):
 
     def _test_call(self, gpu):
         nonlinearity = getattr(F, self.nonlinearity)
-        qf = chainerrl.q_functions.FCLateActionSAQFunction(
+        model = chainerrl.q_functions.FCLateActionSAQFunction(
             n_dim_obs=self.n_dim_obs,
             n_dim_action=self.n_dim_action,
             n_hidden_layers=self.n_hidden_layers,
@@ -220,19 +192,7 @@ class TestFCLateActionSAQFunction(unittest.TestCase):
             nonlinearity=nonlinearity,
             last_wscale=self.last_wscale,
         )
-        batch_size = 7
-        obs = np.random.rand(batch_size, self.n_dim_obs).astype(np.float32)
-        action = np.random.rand(
-            batch_size, self.n_dim_action).astype(np.float32)
-        if gpu >= 0:
-            qf.to_gpu(gpu)
-            obs = chainer.cuda.to_gpu(obs)
-            action = chainer.cuda.to_gpu(action)
-        y = qf(obs, action)
-        self.assertTrue(isinstance(y, chainer.Variable))
-        self.assertEqual(y.shape, (batch_size, 1))
-        self.assertEqual(chainer.cuda.get_array_module(y),
-                         chainer.cuda.get_array_module(obs))
+        self._test_call_given_model(model, gpu)
 
     def test_call_cpu(self):
         self._test_call(gpu=-1)


### PR DESCRIPTION
Please merge this after merging #171 

- Add `nonlinearity` and `last_wscale` aruguments to StateActionQFunctions
- Improve docstrings
- Add tests for StateActionQFunctions. They are actually not checking if each configuration is applied or not, but it should be better than having no test.