### PR TITLE
Improve deterministic policies

### DIFF
--- a/chainerrl/policies/deterministic_policy.py
+++ b/chainerrl/policies/deterministic_policy.py
@@ -15,6 +15,7 @@ from chainer import links as L
 
 from chainerrl import distribution
 from chainerrl.functions.bound_by_tanh import bound_by_tanh
+from chainerrl.initializers import LeCunNormal
 from chainerrl.links.mlp import MLP
 from chainerrl.links.mlp_bn import MLPBN
 from chainerrl.policy import Policy
@@ -53,10 +54,28 @@ class ContinuousDeterministicPolicy(
 
 
 class FCDeterministicPolicy(ContinuousDeterministicPolicy):
+    """Fully-connected deterministic policy.
+
+    Args:
+        n_input_channels (int): Number of input channels.
+        n_hidden_layers (int): Number of hidden layers.
+        n_hidden_channels (int): Number of hidden channels.
+        action_size (int): Size of actions.
+        min_action (ndarray or None): Minimum action. Used only if bound_action
+            is set to True.
+        min_action (ndarray or None): Minimum action. Used only if bound_action
+            is set to True.
+        bound_action (bool): If set to True, actions are bounded to
+            [min_action, max_action] by tanh.
+        nonlinearity (callable): nonlinearity between layers.
+        last_wscale (float): Scale of weight initialization of the last layer.
+    """
 
     def __init__(self, n_input_channels, n_hidden_layers,
                  n_hidden_channels, action_size,
-                 min_action=None, max_action=None, bound_action=True):
+                 min_action=None, max_action=None, bound_action=True,
+                 nonlinearity=F.relu,
+                 last_wscale=1.):
         self.n_input_channels = n_input_channels
         self.n_hidden_layers = n_hidden_layers
         self.n_hidden_channels = n_hidden_channels
@@ -66,24 +85,48 @@ class FCDeterministicPolicy(ContinuousDeterministicPolicy):
         self.bound_action = bound_action
 
         if self.bound_action:
-            action_filter = lambda x: bound_by_tanh(
-                x, self.min_action, self.max_action)
+            def action_filter(x):
+                return bound_by_tanh(
+                    x, self.min_action, self.max_action)
         else:
             action_filter = None
 
         super().__init__(
             model=MLP(n_input_channels,
                       action_size,
-                      (n_hidden_channels,) * n_hidden_layers),
+                      (n_hidden_channels,) * n_hidden_layers,
+                      nonlinearity=nonlinearity,
+                      last_wscale=last_wscale,
+                      ),
             action_filter=action_filter)
 
 
 class FCBNDeterministicPolicy(ContinuousDeterministicPolicy):
+    """Fully-connected deterministic policy with Batch Normalization.
+
+    Args:
+        n_input_channels (int): Number of input channels.
+        n_hidden_layers (int): Number of hidden layers.
+        n_hidden_channels (int): Number of hidden channels.
+        action_size (int): Size of actions.
+        min_action (ndarray or None): Minimum action. Used only if bound_action
+            is set to True.
+        min_action (ndarray or None): Minimum action. Used only if bound_action
+            is set to True.
+        bound_action (bool): If set to True, actions are bounded to
+            [min_action, max_action] by tanh.
+        normalize_input (bool): If set to True, Batch Normalization is applied
+            to inputs as well as hidden activations.
+        nonlinearity (callable): nonlinearity between layers.
+        last_wscale (float): Scale of weight initialization of the last layer.
+    """
 
     def __init__(self, n_input_channels, n_hidden_layers,
                  n_hidden_channels, action_size,
                  min_action=None, max_action=None, bound_action=True,
-                 normalize_input=True):
+                 normalize_input=True,
+                 nonlinearity=F.relu,
+                 last_wscale=1.):
         self.n_input_channels = n_input_channels
         self.n_hidden_layers = n_hidden_layers
         self.n_hidden_channels = n_hidden_channels
@@ -94,8 +137,9 @@ class FCBNDeterministicPolicy(ContinuousDeterministicPolicy):
         self.normalize_input = normalize_input
 
         if self.bound_action:
-            action_filter = lambda x: bound_by_tanh(
-                x, self.min_action, self.max_action)
+            def action_filter(x):
+                return bound_by_tanh(
+                    x, self.min_action, self.max_action)
         else:
             action_filter = None
 
@@ -103,15 +147,36 @@ class FCBNDeterministicPolicy(ContinuousDeterministicPolicy):
             model=MLPBN(n_input_channels,
                         action_size,
                         (n_hidden_channels,) * n_hidden_layers,
-                        normalize_input=self.normalize_input),
+                        normalize_input=self.normalize_input,
+                        nonlinearity=nonlinearity,
+                        last_wscale=last_wscale,
+                        ),
             action_filter=action_filter)
 
 
 class FCLSTMDeterministicPolicy(ContinuousDeterministicPolicy):
+    """Fully-connected deterministic policy with LSTM.
+
+    Args:
+        n_input_channels (int): Number of input channels.
+        n_hidden_layers (int): Number of hidden layers.
+        n_hidden_channels (int): Number of hidden channels.
+        action_size (int): Size of actions.
+        min_action (ndarray or None): Minimum action. Used only if bound_action
+            is set to True.
+        min_action (ndarray or None): Minimum action. Used only if bound_action
+            is set to True.
+        bound_action (bool): If set to True, actions are bounded to
+            [min_action, max_action] by tanh.
+        nonlinearity (callable): nonlinearity between layers.
+        last_wscale (float): Scale of weight initialization of the last layer.
+        """
 
     def __init__(self, n_input_channels, n_hidden_layers,
                  n_hidden_channels, action_size,
-                 min_action=None, max_action=None, bound_action=True):
+                 min_action=None, max_action=None, bound_action=True,
+                 nonlinearity=F.relu,
+                 last_wscale=1.):
         self.n_input_channels = n_input_channels
         self.n_hidden_layers = n_hidden_layers
         self.n_hidden_channels = n_hidden_channels
@@ -121,21 +186,25 @@ class FCLSTMDeterministicPolicy(ContinuousDeterministicPolicy):
         self.bound_action = bound_action
 
         if self.bound_action:
-            action_filter = lambda x: bound_by_tanh(
-                x, self.min_action, self.max_action)
+            def action_filter(x):
+                return bound_by_tanh(
+                    x, self.min_action, self.max_action)
         else:
             action_filter = None
 
         model = chainer.Chain(
             fc=MLP(self.n_input_channels,
                    n_hidden_channels,
-                   (self.n_hidden_channels,) * self.n_hidden_layers),
+                   (self.n_hidden_channels,) * self.n_hidden_layers,
+                   nonlinearity=nonlinearity,
+                   ),
             lstm=L.LSTM(n_hidden_channels, n_hidden_channels),
-            out=L.Linear(n_hidden_channels, action_size),
+            out=L.Linear(n_hidden_channels, action_size,
+                         initialW=LeCunNormal(last_wscale)),
         )
 
         def model_call(model, x):
-            h = F.relu(model.fc(x))
+            h = nonlinearity(model.fc(x))
             h = model.lstm(h)
             h = model.out(h)
             return h

--- a/chainerrl/policies/deterministic_policy.py
+++ b/chainerrl/policies/deterministic_policy.py
@@ -67,7 +67,10 @@ class FCDeterministicPolicy(ContinuousDeterministicPolicy):
             is set to True.
         bound_action (bool): If set to True, actions are bounded to
             [min_action, max_action] by tanh.
-        nonlinearity (callable): nonlinearity between layers.
+        nonlinearity (callable): Nonlinearity between layers. It must accept a
+            Variable as an argument and return a Variable with the same shape.
+            Nonlinearities with learnable parameters such as PReLU are not
+            supported.
         last_wscale (float): Scale of weight initialization of the last layer.
     """
 
@@ -117,7 +120,10 @@ class FCBNDeterministicPolicy(ContinuousDeterministicPolicy):
             [min_action, max_action] by tanh.
         normalize_input (bool): If set to True, Batch Normalization is applied
             to inputs as well as hidden activations.
-        nonlinearity (callable): nonlinearity between layers.
+        nonlinearity (callable): Nonlinearity between layers. It must accept a
+            Variable as an argument and return a Variable with the same shape.
+            Nonlinearities with learnable parameters such as PReLU are not
+            supported.
         last_wscale (float): Scale of weight initialization of the last layer.
     """
 
@@ -168,7 +174,10 @@ class FCLSTMDeterministicPolicy(ContinuousDeterministicPolicy):
             is set to True.
         bound_action (bool): If set to True, actions are bounded to
             [min_action, max_action] by tanh.
-        nonlinearity (callable): nonlinearity between layers.
+        nonlinearity (callable): Nonlinearity between layers. It must accept a
+            Variable as an argument and return a Variable with the same shape.
+            Nonlinearities with learnable parameters such as PReLU are not
+            supported.
         last_wscale (float): Scale of weight initialization of the last layer.
         """
 

--- a/chainerrl/policies/deterministic_policy.py
+++ b/chainerrl/policies/deterministic_policy.py
@@ -70,7 +70,7 @@ class FCDeterministicPolicy(ContinuousDeterministicPolicy):
         nonlinearity (callable): Nonlinearity between layers. It must accept a
             Variable as an argument and return a Variable with the same shape.
             Nonlinearities with learnable parameters such as PReLU are not
-            supported.
+            supported. It is not used if n_hidden_layers is zero.
         last_wscale (float): Scale of weight initialization of the last layer.
     """
 
@@ -123,7 +123,7 @@ class FCBNDeterministicPolicy(ContinuousDeterministicPolicy):
         nonlinearity (callable): Nonlinearity between layers. It must accept a
             Variable as an argument and return a Variable with the same shape.
             Nonlinearities with learnable parameters such as PReLU are not
-            supported.
+            supported. It is not used if n_hidden_layers is zero.
         last_wscale (float): Scale of weight initialization of the last layer.
     """
 

--- a/tests/policies_tests/test_deterministic_policy.py
+++ b/tests/policies_tests/test_deterministic_policy.py
@@ -8,12 +8,11 @@ standard_library.install_aliases()
 
 import unittest
 
-import numpy as np
-
 import chainer
 import chainer.functions as F
 from chainer import testing
 from chainer.testing import attr
+import numpy as np
 
 import chainerrl
 

--- a/tests/policies_tests/test_deterministic_policy.py
+++ b/tests/policies_tests/test_deterministic_policy.py
@@ -1,0 +1,162 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()
+
+import unittest
+
+import numpy as np
+
+import chainer
+import chainer.functions as F
+from chainer import testing
+from chainer.testing import attr
+
+import chainerrl
+
+
+class _TestDeterministicPolicy(unittest.TestCase):
+
+    def _test_call_given_model(self, model, gpu):
+        # This method only check if a given model can receive random input
+        # data and return output data with the correct interface.
+        min_action = np.full((self.action_size,), -0.01, dtype=np.float32)
+        max_action = np.full((self.action_size,), 0.01, dtype=np.float32)
+        batch_size = 7
+        x = np.random.rand(
+            batch_size, self.n_input_channels).astype(np.float32)
+        if gpu >= 0:
+            model.to_gpu(gpu)
+            x = chainer.cuda.to_gpu(x)
+            min_action = chainer.cuda.to_gpu(min_action)
+            max_action = chainer.cuda.to_gpu(max_action)
+        y = model(x)
+        self.assertTrue(isinstance(
+            y, chainerrl.distribution.ContinuousDeterministicDistribution))
+        a = y.sample()
+        self.assertTrue(isinstance(a, chainer.Variable))
+        self.assertEqual(a.shape, (batch_size, self.action_size))
+        self.assertEqual(chainer.cuda.get_array_module(a),
+                         chainer.cuda.get_array_module(x))
+        if self.bound_action:
+            self.assertTrue((a.data <= max_action).all())
+            self.assertTrue((a.data >= min_action).all())
+
+
+@testing.parameterize(
+    *testing.product({
+        'n_input_channels': [1, 5],
+        'n_hidden_layers': [0, 1, 2],
+        'n_hidden_channels': [1, 2],
+        'action_size': [1, 2],
+        'bound_action': [True, False],
+        'nonlinearity': ['relu', 'elu'],
+        'last_wscale': [1, 1e-3],
+    })
+)
+class TestFCDeterministicPolicy(_TestDeterministicPolicy):
+
+    def _test_call(self, gpu):
+        nonlinearity = getattr(F, self.nonlinearity)
+        min_action = np.full((self.action_size,), -0.01, dtype=np.float32)
+        max_action = np.full((self.action_size,), 0.01, dtype=np.float32)
+        model = chainerrl.policies.FCDeterministicPolicy(
+            n_input_channels=self.n_input_channels,
+            n_hidden_layers=self.n_hidden_layers,
+            n_hidden_channels=self.n_hidden_channels,
+            action_size=self.action_size,
+            bound_action=self.bound_action,
+            min_action=min_action,
+            max_action=max_action,
+            nonlinearity=nonlinearity,
+            last_wscale=self.last_wscale,
+        )
+        self._test_call_given_model(model, gpu)
+
+    def test_call_cpu(self):
+        self._test_call(gpu=-1)
+
+    @attr.gpu
+    def test_call_gpu(self):
+        self._test_call(gpu=0)
+
+
+@testing.parameterize(
+    *testing.product({
+        'n_input_channels': [1, 5],
+        'n_hidden_layers': [0, 1, 2],
+        'n_hidden_channels': [1, 2],
+        'action_size': [1, 2],
+        'bound_action': [True, False],
+        'normalize_input': [True, False],
+        'nonlinearity': ['relu', 'elu'],
+        'last_wscale': [1, 1e-3],
+    })
+)
+class TestFCBNDeterministicPolicy(_TestDeterministicPolicy):
+
+    def _test_call(self, gpu):
+        nonlinearity = getattr(F, self.nonlinearity)
+        min_action = np.full((self.action_size,), -0.01, dtype=np.float32)
+        max_action = np.full((self.action_size,), 0.01, dtype=np.float32)
+        model = chainerrl.policies.FCBNDeterministicPolicy(
+            n_input_channels=self.n_input_channels,
+            n_hidden_layers=self.n_hidden_layers,
+            n_hidden_channels=self.n_hidden_channels,
+            action_size=self.action_size,
+            bound_action=self.bound_action,
+            min_action=min_action,
+            max_action=max_action,
+            normalize_input=self.normalize_input,
+            nonlinearity=nonlinearity,
+            last_wscale=self.last_wscale,
+        )
+        self._test_call_given_model(model, gpu)
+
+    def test_call_cpu(self):
+        self._test_call(gpu=-1)
+
+    @attr.gpu
+    def test_call_gpu(self):
+        self._test_call(gpu=0)
+
+
+@testing.parameterize(
+    *testing.product({
+        'n_input_channels': [1, 5],
+        'n_hidden_layers': [0, 1, 2],
+        'n_hidden_channels': [1, 2],
+        'action_size': [1, 2],
+        'bound_action': [True, False],
+        'nonlinearity': ['relu', 'elu'],
+        'last_wscale': [1, 1e-3],
+    })
+)
+class TestFCLSTMDeterministicPolicy(_TestDeterministicPolicy):
+
+    def _test_call(self, gpu):
+        nonlinearity = getattr(F, self.nonlinearity)
+        min_action = np.full((self.action_size,), -0.01, dtype=np.float32)
+        max_action = np.full((self.action_size,), 0.01, dtype=np.float32)
+        model = chainerrl.policies.FCLSTMDeterministicPolicy(
+            n_input_channels=self.n_input_channels,
+            n_hidden_layers=self.n_hidden_layers,
+            n_hidden_channels=self.n_hidden_channels,
+            action_size=self.action_size,
+            bound_action=self.bound_action,
+            min_action=min_action,
+            max_action=max_action,
+            nonlinearity=nonlinearity,
+            last_wscale=self.last_wscale,
+        )
+        self._test_call_given_model(model, gpu)
+
+    def test_call_cpu(self):
+        self._test_call(gpu=-1)
+
+    @attr.gpu
+    def test_call_gpu(self):
+        self._test_call(gpu=0)

--- a/tests/policies_tests/test_deterministic_policy.py
+++ b/tests/policies_tests/test_deterministic_policy.py
@@ -48,12 +48,14 @@ class _TestDeterministicPolicy(unittest.TestCase):
 @testing.parameterize(
     *testing.product({
         'n_input_channels': [1, 5],
-        'n_hidden_layers': [0, 1, 2],
-        'n_hidden_channels': [1, 2],
         'action_size': [1, 2],
         'bound_action': [True, False],
         'nonlinearity': ['relu', 'elu'],
-        'last_wscale': [1, 1e-3],
+        'model_kwargs': testing.product({
+            'n_hidden_layers': [0, 1, 2],
+            'n_hidden_channels': [1, 2],
+            'last_wscale': [1, 1e-3],
+        }),
     })
 )
 class TestFCDeterministicPolicy(_TestDeterministicPolicy):
@@ -64,14 +66,12 @@ class TestFCDeterministicPolicy(_TestDeterministicPolicy):
         max_action = np.full((self.action_size,), 0.01, dtype=np.float32)
         model = chainerrl.policies.FCDeterministicPolicy(
             n_input_channels=self.n_input_channels,
-            n_hidden_layers=self.n_hidden_layers,
-            n_hidden_channels=self.n_hidden_channels,
             action_size=self.action_size,
             bound_action=self.bound_action,
             min_action=min_action,
             max_action=max_action,
             nonlinearity=nonlinearity,
-            last_wscale=self.last_wscale,
+            **self.model_kwargs,
         )
         self._test_call_given_model(model, gpu)
 
@@ -86,13 +86,15 @@ class TestFCDeterministicPolicy(_TestDeterministicPolicy):
 @testing.parameterize(
     *testing.product({
         'n_input_channels': [1, 5],
-        'n_hidden_layers': [0, 1, 2],
-        'n_hidden_channels': [1, 2],
         'action_size': [1, 2],
         'bound_action': [True, False],
-        'normalize_input': [True, False],
         'nonlinearity': ['relu', 'elu'],
-        'last_wscale': [1, 1e-3],
+        'model_kwargs': testing.product({
+            'n_hidden_layers': [0, 1, 2],
+            'n_hidden_channels': [1, 2],
+            'normalize_input': [True, False],
+            'last_wscale': [1, 1e-3],
+        }),
     })
 )
 class TestFCBNDeterministicPolicy(_TestDeterministicPolicy):
@@ -103,15 +105,12 @@ class TestFCBNDeterministicPolicy(_TestDeterministicPolicy):
         max_action = np.full((self.action_size,), 0.01, dtype=np.float32)
         model = chainerrl.policies.FCBNDeterministicPolicy(
             n_input_channels=self.n_input_channels,
-            n_hidden_layers=self.n_hidden_layers,
-            n_hidden_channels=self.n_hidden_channels,
             action_size=self.action_size,
             bound_action=self.bound_action,
             min_action=min_action,
             max_action=max_action,
-            normalize_input=self.normalize_input,
             nonlinearity=nonlinearity,
-            last_wscale=self.last_wscale,
+            **self.model_kwargs,
         )
         self._test_call_given_model(model, gpu)
 
@@ -126,12 +125,14 @@ class TestFCBNDeterministicPolicy(_TestDeterministicPolicy):
 @testing.parameterize(
     *testing.product({
         'n_input_channels': [1, 5],
-        'n_hidden_layers': [0, 1, 2],
-        'n_hidden_channels': [1, 2],
         'action_size': [1, 2],
         'bound_action': [True, False],
         'nonlinearity': ['relu', 'elu'],
-        'last_wscale': [1, 1e-3],
+        'model_kwargs': testing.product({
+            'n_hidden_layers': [0, 1, 2],
+            'n_hidden_channels': [1, 2],
+            'last_wscale': [1, 1e-3],
+        }),
     })
 )
 class TestFCLSTMDeterministicPolicy(_TestDeterministicPolicy):
@@ -142,14 +143,12 @@ class TestFCLSTMDeterministicPolicy(_TestDeterministicPolicy):
         max_action = np.full((self.action_size,), 0.01, dtype=np.float32)
         model = chainerrl.policies.FCLSTMDeterministicPolicy(
             n_input_channels=self.n_input_channels,
-            n_hidden_layers=self.n_hidden_layers,
-            n_hidden_channels=self.n_hidden_channels,
             action_size=self.action_size,
             bound_action=self.bound_action,
             min_action=min_action,
             max_action=max_action,
             nonlinearity=nonlinearity,
-            last_wscale=self.last_wscale,
+            **self.model_kwargs,
         )
         self._test_call_given_model(model, gpu)
 

--- a/tests/policies_tests/test_deterministic_policy.py
+++ b/tests/policies_tests/test_deterministic_policy.py
@@ -17,8 +17,8 @@ import numpy as np
 import chainerrl
 
 
-@testing.parameterize(
-    *testing.product({
+@testing.parameterize(*(
+    testing.product({
         'n_input_channels': [1, 5],
         'action_size': [1, 2],
         'bound_action': [True, False],
@@ -29,8 +29,8 @@ import chainerrl
             'n_hidden_channels': [1, 2],
             'last_wscale': [1, 1e-3],
         }),
-    }),
-    *testing.product({
+    }) +
+    testing.product({
         'n_input_channels': [1, 5],
         'action_size': [1, 2],
         'bound_action': [True, False],
@@ -42,8 +42,8 @@ import chainerrl
             'normalize_input': [True, False],
             'last_wscale': [1, 1e-3],
         }),
-    }),
-    *testing.product({
+    }) +
+    testing.product({
         'n_input_channels': [1, 5],
         'action_size': [1, 2],
         'bound_action': [True, False],
@@ -55,8 +55,12 @@ import chainerrl
             'last_wscale': [1, 1e-3],
         }),
     })
-)
+))
 class TestDeterministicPolicy(unittest.TestCase):
+
+    def _make_model(self, **kwargs):
+        kwargs.update(self.model_kwargs)
+        return self.model_class(**kwargs)
 
     def _test_call(self, gpu):
         # This method only check if a given model can receive random input
@@ -64,14 +68,13 @@ class TestDeterministicPolicy(unittest.TestCase):
         nonlinearity = getattr(F, self.nonlinearity)
         min_action = np.full((self.action_size,), -0.01, dtype=np.float32)
         max_action = np.full((self.action_size,), 0.01, dtype=np.float32)
-        model = self.model_class(
+        model = self._make_model(
             n_input_channels=self.n_input_channels,
             action_size=self.action_size,
             bound_action=self.bound_action,
             min_action=min_action,
             max_action=max_action,
             nonlinearity=nonlinearity,
-            **self.model_kwargs,
         )
 
         batch_size = 7

--- a/tests/policies_tests/test_deterministic_policy.py
+++ b/tests/policies_tests/test_deterministic_policy.py
@@ -17,13 +17,63 @@ import numpy as np
 import chainerrl
 
 
-class _TestDeterministicPolicy(unittest.TestCase):
+@testing.parameterize(
+    *testing.product({
+        'n_input_channels': [1, 5],
+        'action_size': [1, 2],
+        'bound_action': [True, False],
+        'nonlinearity': ['relu', 'elu'],
+        'model_class': [chainerrl.policies.FCDeterministicPolicy],
+        'model_kwargs': testing.product({
+            'n_hidden_layers': [0, 1, 2],
+            'n_hidden_channels': [1, 2],
+            'last_wscale': [1, 1e-3],
+        }),
+    }),
+    *testing.product({
+        'n_input_channels': [1, 5],
+        'action_size': [1, 2],
+        'bound_action': [True, False],
+        'nonlinearity': ['relu', 'elu'],
+        'model_class': [chainerrl.policies.FCBNDeterministicPolicy],
+        'model_kwargs': testing.product({
+            'n_hidden_layers': [0, 1, 2],
+            'n_hidden_channels': [1, 2],
+            'normalize_input': [True, False],
+            'last_wscale': [1, 1e-3],
+        }),
+    }),
+    *testing.product({
+        'n_input_channels': [1, 5],
+        'action_size': [1, 2],
+        'bound_action': [True, False],
+        'nonlinearity': ['relu', 'elu'],
+        'model_class': [chainerrl.policies.FCLSTMDeterministicPolicy],
+        'model_kwargs': testing.product({
+            'n_hidden_layers': [0, 1, 2],
+            'n_hidden_channels': [1, 2],
+            'last_wscale': [1, 1e-3],
+        }),
+    })
+)
+class TestDeterministicPolicy(unittest.TestCase):
 
-    def _test_call_given_model(self, model, gpu):
+    def _test_call(self, gpu):
         # This method only check if a given model can receive random input
         # data and return output data with the correct interface.
+        nonlinearity = getattr(F, self.nonlinearity)
         min_action = np.full((self.action_size,), -0.01, dtype=np.float32)
         max_action = np.full((self.action_size,), 0.01, dtype=np.float32)
+        model = self.model_class(
+            n_input_channels=self.n_input_channels,
+            action_size=self.action_size,
+            bound_action=self.bound_action,
+            min_action=min_action,
+            max_action=max_action,
+            nonlinearity=nonlinearity,
+            **self.model_kwargs,
+        )
+
         batch_size = 7
         x = np.random.rand(
             batch_size, self.n_input_channels).astype(np.float32)
@@ -43,114 +93,6 @@ class _TestDeterministicPolicy(unittest.TestCase):
         if self.bound_action:
             self.assertTrue((a.data <= max_action).all())
             self.assertTrue((a.data >= min_action).all())
-
-
-@testing.parameterize(
-    *testing.product({
-        'n_input_channels': [1, 5],
-        'action_size': [1, 2],
-        'bound_action': [True, False],
-        'nonlinearity': ['relu', 'elu'],
-        'model_kwargs': testing.product({
-            'n_hidden_layers': [0, 1, 2],
-            'n_hidden_channels': [1, 2],
-            'last_wscale': [1, 1e-3],
-        }),
-    })
-)
-class TestFCDeterministicPolicy(_TestDeterministicPolicy):
-
-    def _test_call(self, gpu):
-        nonlinearity = getattr(F, self.nonlinearity)
-        min_action = np.full((self.action_size,), -0.01, dtype=np.float32)
-        max_action = np.full((self.action_size,), 0.01, dtype=np.float32)
-        model = chainerrl.policies.FCDeterministicPolicy(
-            n_input_channels=self.n_input_channels,
-            action_size=self.action_size,
-            bound_action=self.bound_action,
-            min_action=min_action,
-            max_action=max_action,
-            nonlinearity=nonlinearity,
-            **self.model_kwargs,
-        )
-        self._test_call_given_model(model, gpu)
-
-    def test_call_cpu(self):
-        self._test_call(gpu=-1)
-
-    @attr.gpu
-    def test_call_gpu(self):
-        self._test_call(gpu=0)
-
-
-@testing.parameterize(
-    *testing.product({
-        'n_input_channels': [1, 5],
-        'action_size': [1, 2],
-        'bound_action': [True, False],
-        'nonlinearity': ['relu', 'elu'],
-        'model_kwargs': testing.product({
-            'n_hidden_layers': [0, 1, 2],
-            'n_hidden_channels': [1, 2],
-            'normalize_input': [True, False],
-            'last_wscale': [1, 1e-3],
-        }),
-    })
-)
-class TestFCBNDeterministicPolicy(_TestDeterministicPolicy):
-
-    def _test_call(self, gpu):
-        nonlinearity = getattr(F, self.nonlinearity)
-        min_action = np.full((self.action_size,), -0.01, dtype=np.float32)
-        max_action = np.full((self.action_size,), 0.01, dtype=np.float32)
-        model = chainerrl.policies.FCBNDeterministicPolicy(
-            n_input_channels=self.n_input_channels,
-            action_size=self.action_size,
-            bound_action=self.bound_action,
-            min_action=min_action,
-            max_action=max_action,
-            nonlinearity=nonlinearity,
-            **self.model_kwargs,
-        )
-        self._test_call_given_model(model, gpu)
-
-    def test_call_cpu(self):
-        self._test_call(gpu=-1)
-
-    @attr.gpu
-    def test_call_gpu(self):
-        self._test_call(gpu=0)
-
-
-@testing.parameterize(
-    *testing.product({
-        'n_input_channels': [1, 5],
-        'action_size': [1, 2],
-        'bound_action': [True, False],
-        'nonlinearity': ['relu', 'elu'],
-        'model_kwargs': testing.product({
-            'n_hidden_layers': [0, 1, 2],
-            'n_hidden_channels': [1, 2],
-            'last_wscale': [1, 1e-3],
-        }),
-    })
-)
-class TestFCLSTMDeterministicPolicy(_TestDeterministicPolicy):
-
-    def _test_call(self, gpu):
-        nonlinearity = getattr(F, self.nonlinearity)
-        min_action = np.full((self.action_size,), -0.01, dtype=np.float32)
-        max_action = np.full((self.action_size,), 0.01, dtype=np.float32)
-        model = chainerrl.policies.FCLSTMDeterministicPolicy(
-            n_input_channels=self.n_input_channels,
-            action_size=self.action_size,
-            bound_action=self.bound_action,
-            min_action=min_action,
-            max_action=max_action,
-            nonlinearity=nonlinearity,
-            **self.model_kwargs,
-        )
-        self._test_call_given_model(model, gpu)
 
     def test_call_cpu(self):
         self._test_call(gpu=-1)


### PR DESCRIPTION
Please merge this after #171 and #172 are merged.

- Add `nonlinearity` and `last_wscale` to deterministic policies.
- Improve docstrings
- Add tests for deterministic policies