### PR TITLE
Use bytestrings to write git outputs

### DIFF
--- a/chainerrl/experiments/prepare_output_dir.py
+++ b/chainerrl/experiments/prepare_output_dir.py
@@ -97,19 +97,19 @@ def prepare_output_dir(args, user_specified_dir=None, argv=None,
 
     if is_under_git_control():
         # Save `git rev-parse HEAD` (SHA of the current commit)
-        with open(os.path.join(outdir, 'git-head.txt'), 'w') as f:
-            f.write(subprocess.getoutput('git rev-parse HEAD'))
+        with open(os.path.join(outdir, 'git-head.txt'), 'wb') as f:
+            f.write(subprocess.check_output('git rev-parse HEAD'.split()))
 
         # Save `git status`
-        with open(os.path.join(outdir, 'git-status.txt'), 'w') as f:
-            f.write(subprocess.getoutput('git status'))
+        with open(os.path.join(outdir, 'git-status.txt'), 'wb') as f:
+            f.write(subprocess.check_output('git status'.split()))
 
         # Save `git log`
-        with open(os.path.join(outdir, 'git-log.txt'), 'w') as f:
-            f.write(subprocess.getoutput('git log'))
+        with open(os.path.join(outdir, 'git-log.txt'), 'wb') as f:
+            f.write(subprocess.check_output('git log'.split()))
 
         # Save `git diff`
-        with open(os.path.join(outdir, 'git-diff.txt'), 'w') as f:
-            f.write(subprocess.getoutput('git diff'))
+        with open(os.path.join(outdir, 'git-diff.txt'), 'wb') as f:
+            f.write(subprocess.check_output('git diff'.split()))
 
     return outdir

--- a/tests/experiments_tests/test_prepare_output_dir.py
+++ b/tests/experiments_tests/test_prepare_output_dir.py
@@ -73,6 +73,12 @@ class TestPrepareOutputDir(unittest.TestCase):
 
             if self.git:
                 subprocess.call(['git', 'init'])
+                with open('not_utf-8.txt', 'wb') as f:
+                    f.write(b'\x80')
+                subprocess.call(['git', 'add', 'not_utf-8.txt'])
+                subprocess.call(['git', 'commit', '-m' 'commit1'])
+                with open('not_utf-8.txt', 'wb') as f:
+                    f.write(b'\x81')
 
             dirname = chainerrl.experiments.prepare_output_dir(
                 args,


### PR DESCRIPTION
- The first commit tests `prepare_output_dir` on condition that `git diff` is nontrivial.
  - If diff of a text file contains an invalid utf-8 sequence, the output of `git diff` seems to contain an invalid sequence, too.
- The second commit fixes the bug.

The current code fails the new test: `python -m unittest tests/experiments_tests/test_prepare_output_dir.py` results
```
Ran 18 tests in 2.303s

FAILED (errors=8)
```
with e.g.
```
======================================================================
ERROR: test_prepare_output_dir (chainer.testing.parameterized.TestPrepareOutputDir_param_0)  parameter: {'argv': ['command', '--option'], 'git': True, 'time_format': '%Y%m%dT%H%M%S.%f', 'user_specified_dir': '/var/folders/zk/2tl6l77170d2b51fczxysjsw0000gn/T/tmpjqbi2uii'}
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/tos/Documents/chainerrl/tests/experiments_tests/test_prepare_output_dir.py", line 86, in test_prepare_output_dir
    argv=self.argv)
  File "/Users/tos/Documents/chainerrl/chainerrl/experiments/prepare_output_dir.py", line 113, in prepare_output_dir
    f.write(subprocess.getoutput('git diff'))
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 534, in getoutput
    return getstatusoutput(cmd)[1]
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 515, in getstatusoutput
    data = check_output(cmd, shell=True, universal_newlines=True, stderr=STDOUT)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 405, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 825, in communicate
    stdout = self.stdout.read()
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 126: invalid start byte
```