### PR TITLE
Mark TestBiasCorrection as slow

### DIFF
--- a/tests/agents_tests/test_acer.py
+++ b/tests/agents_tests/test_acer.py
@@ -128,6 +128,7 @@ class TestBiasCorrection(unittest.TestCase):
     def setUp(self):
         pass
 
+    @testing.attr.slow
     @condition.retry(3)
     def test_bias_correction(self):
 


### PR DESCRIPTION
Resolves #179.

After this PR, tests/agents_tests/test_acer.py will contain
- non-slow tests: `Ran 290 tests in 26.788s`, and
- slow tests: `Ran 132 tests in 772.546s`.

(All the tests in the file run without gpus.)