### PR TITLE
Add coroutine interface and use it in agents.DQN

### DIFF
--- a/chainerrl/agents/dqn.py
+++ b/chainerrl/agents/dqn.py
@@ -461,7 +461,7 @@ class DQN(agent.AttributeSavingMixin, agent.EpisodicActsMixin, agent.Agent):
                     state=last_state,
                     action=last_action,
                     reward=reward,
-                    next_state=last_state,
+                    next_state=state,
                     next_action=action,
                     is_state_terminal=is_state_terminal)
 

--- a/chainerrl/agents/dqn.py
+++ b/chainerrl/agents/dqn.py
@@ -91,7 +91,7 @@ def compute_weighted_value_loss(y, t, weights,
     return loss
 
 
-class DQN(agent.AttributeSavingMixin, agent.EpisodicActsMixin, agent.Agent):
+class DQN(agent.AttributeSavingMixin, agent.ActStepMixin, agent.Agent):
     """Deep Q-Network algorithm.
 
     Args:


### PR DESCRIPTION
The PR introduces a coroutine interface for agent to interact in an episode.

```
action = session.send((obs, reward, stop))
```
where the last flag `stop` terminates the coroutine.  Send `(None, reward, True)` to tell the last transition was terminal.
 
The interface would be used from a training loop.  Besides, this PR removes `self.last_state`, `self.last_action`, etc.