### PR TITLE
Use coroutine interface in A3C

### DIFF
--- a/chainerrl/agent.py
+++ b/chainerrl/agent.py
@@ -152,14 +152,14 @@ class EpisodicActsMixin(object):
             pass
         else:
             if done:
-                session.close()
+                obs = None
+
+            try:
+                session.send((obs, reward, True))
+            except StopIteration:
+                pass
             else:
-                try:
-                    session.send((obs, reward, True))
-                except StopIteration:
-                    pass
-                else:
-                    assert False
+                assert False
             del self._ep_train_session
 
     def stop_episode(self):
@@ -168,7 +168,12 @@ class EpisodicActsMixin(object):
         except AttributeError:
             pass
         else:
-            session.close()
+            try:
+                session.send(None)
+            except StopIteration:
+                pass
+            else:
+                assert False
             del self._ep_session
 
 

--- a/chainerrl/agents/a3c.py
+++ b/chainerrl/agents/a3c.py
@@ -77,7 +77,8 @@ class A3CSharedModel(chainer.Chain, A3CModel, RecurrentChainMixin):
         return pout, vout
 
 
-class A3C(agent.AttributeSavingMixin, agent.EpisodicActsMixin, agent.AsyncAgent):
+class A3C(agent.AttributeSavingMixin, agent.EpisodicActsMixin,
+          agent.AsyncAgent):
     """A3C: Asynchronous Advantage Actor-Critic.
 
     See http://arxiv.org/abs/1602.01783
@@ -161,7 +162,7 @@ class A3C(agent.AttributeSavingMixin, agent.EpisodicActsMixin, agent.AsyncAgent)
                past_states,
                past_rewards,
                past_values,
-            ):
+               ):
         assert t_start < self.t
 
         if state is None:
@@ -253,7 +254,8 @@ class A3C(agent.AttributeSavingMixin, agent.EpisodicActsMixin, agent.AsyncAgent)
             while self.t - t_start < self.t_max and not halt:
                 past_states[self.t] = state
                 pout, vout = self.model.pi_and_v(state)
-                action = pout.sample().data  # Do not backprop through sampled actions
+                # Do not backprop through sampled actions
+                action = pout.sample().data
                 past_action_log_prob[self.t] = pout.log_prob(action)
                 past_action_entropy[self.t] = pout.entropy
                 past_values[self.t] = vout

--- a/chainerrl/agents/a3c.py
+++ b/chainerrl/agents/a3c.py
@@ -159,14 +159,12 @@ class A3C(agent.AttributeSavingMixin, agent.EpisodicActsMixin,
     def update(self, state,
                past_action_log_prob,
                past_action_entropy,
-               past_states,
                past_rewards,
                past_values,
                ):
         t_length = len(past_action_log_prob)
         assert t_length \
             == len(past_action_entropy) \
-            == len(past_states) \
             == len(past_rewards) \
             == len(past_values)
 
@@ -251,12 +249,10 @@ class A3C(agent.AttributeSavingMixin, agent.EpisodicActsMixin,
         while not halt:
             past_action_log_prob = []
             past_action_entropy = []
-            past_states = []
             past_rewards = []
             past_values = []
 
             while len(past_rewards) < self.t_max and not halt:
-                past_states.append(state)
                 pout, vout = self.model.pi_and_v(state)
                 # Do not backprop through sampled actions
                 action = pout.sample().data
@@ -288,7 +284,6 @@ class A3C(agent.AttributeSavingMixin, agent.EpisodicActsMixin,
                 state,
                 past_action_log_prob,
                 past_action_entropy,
-                past_states,
                 past_rewards,
                 past_values,
             )

--- a/chainerrl/agents/a3c.py
+++ b/chainerrl/agents/a3c.py
@@ -234,8 +234,6 @@ class A3C(agent.AttributeSavingMixin, agent.EpisodicActsMixin, agent.AsyncAgent)
             logger.debug('update')
 
         self.sync_parameters()
-        if isinstance(self.model, Recurrent):
-            self.model.unchain_backward()
 
     def act_and_train_episode(self, state):
         if isinstance(self.model, Recurrent):
@@ -288,6 +286,8 @@ class A3C(agent.AttributeSavingMixin, agent.EpisodicActsMixin, agent.AsyncAgent)
                 past_rewards,
                 past_values,
             )
+            if isinstance(self.model, Recurrent):
+                self.model.unchain_backward()
 
     def act_episode(self, state):
         # Use the process-local model for acting


### PR DESCRIPTION
see #183.

Changed: do
```
                    logger.debug('t:%s r:%s a:%s pout:%s',
                                 self.t, reward, action, pout)
```
after the agent gets `reward`.
