### PR TITLE
Added agent test for act without train (e.g. batch normalization)

### DIFF
--- a/chainerrl/agents/a3c.py
+++ b/chainerrl/agents/a3c.py
@@ -276,7 +276,7 @@ class A3C(agent.AttributeSavingMixin, agent.AsyncAgent):
 
     def act(self, obs):
         # Use the process-local model for acting
-        with chainer.no_backprop_mode():
+        with chainer.no_backprop_mode(), chainer.using_config('train', False):
             statevar = self.batch_states([obs], np, self.phi)
             pout, _ = self.model.pi_and_v(statevar)
             if self.act_deterministically:

--- a/chainerrl/agents/acer.py
+++ b/chainerrl/agents/acer.py
@@ -672,7 +672,7 @@ class ACER(agent.AttributeSavingMixin, agent.AsyncAgent):
 
     def act(self, obs):
         # Use the process-local model for acting
-        with chainer.no_backprop_mode():
+        with chainer.no_backprop_mode(), chainer.using_config('train', False):
             statevar = np.expand_dims(self.phi(obs), 0)
             action_distrib, _, _ = self.model(statevar)
             if self.act_deterministically:

--- a/chainerrl/agents/reinforce.py
+++ b/chainerrl/agents/reinforce.py
@@ -76,8 +76,9 @@ class REINFORCE(agent.AttributeSavingMixin, agent.Agent):
     def act_and_train(self, obs, reward):
 
         batch_obs = self.batch_states([obs], self.xp, self.phi)
-        action_distrib = self.model(batch_obs)
-        batch_action = action_distrib.sample().data  # Do not backprop
+        with chainer.no_backprop_mode(), chainer.using_config('train', False):
+            action_distrib = self.model(batch_obs)
+            batch_action = action_distrib.sample().data  # Do not backprop
         action = chainer.cuda.to_cpu(batch_action)[0]
 
         # Save values used to compute losses
@@ -100,7 +101,7 @@ class REINFORCE(agent.AttributeSavingMixin, agent.Agent):
         return action
 
     def act(self, obs):
-        with chainer.no_backprop_mode():
+        with chainer.no_backprop_mode(), chainer.using_config('train', False):
             batch_obs = self.batch_states([obs], self.xp, self.phi)
             action_distrib = self.model(batch_obs)
             if self.act_deterministically:

--- a/chainerrl/policies/softmax_policy.py
+++ b/chainerrl/policies/softmax_policy.py
@@ -14,6 +14,7 @@ from chainer import functions as F
 
 from chainerrl import distribution
 from chainerrl.links.mlp import MLP
+from chainerrl.links.mlp_bn import MLPBN
 from chainerrl.policy import Policy
 
 
@@ -58,5 +59,32 @@ class FCSoftmaxPolicy(SoftmaxPolicy):
                       (n_hidden_channels,) * n_hidden_layers,
                       nonlinearity=nonlinearity,
                       last_wscale=last_wscale),
+            beta=self.beta,
+            min_prob=min_prob)
+
+
+class FCBNSoftmaxPolicy(SoftmaxPolicy):
+    """Softmax policy that consists of FC layers and rectifiers"""
+
+    def __init__(self, n_input_channels, n_actions,
+                 n_hidden_layers=0, n_hidden_channels=None,
+                 beta=1.0,
+                 normalize_input=True,
+                 nonlinearity=F.relu,
+                 last_wscale=1.0,
+                 min_prob=0.0):
+        self.n_input_channels = n_input_channels
+        self.n_actions = n_actions
+        self.n_hidden_layers = n_hidden_layers
+        self.n_hidden_channels = n_hidden_channels
+        self.beta = beta
+
+        super().__init__(
+            model=MLPBN(n_input_channels,
+                        n_actions,
+                        [n_hidden_channels] * n_hidden_layers,
+                        normalize_input=normalize_input,
+                        nonlinearity=nonlinearity,
+                        last_wscale=last_wscale),
             beta=self.beta,
             min_prob=min_prob)

--- a/chainerrl/v_functions/v_functions.py
+++ b/chainerrl/v_functions/v_functions.py
@@ -10,6 +10,7 @@ import chainer
 from chainer import functions as F
 
 from chainerrl.links.mlp import MLP
+from chainerrl.links.mlp_bn import MLPBN
 from chainerrl.recurrent import RecurrentChainMixin
 from chainerrl.v_function import VFunction
 
@@ -34,7 +35,8 @@ class SingleModelVFunction(
 class FCVFunction(SingleModelVFunction):
 
     def __init__(self, n_input_channels, n_hidden_layers=0,
-                 n_hidden_channels=None, nonlinearity=F.relu,
+                 n_hidden_channels=None,
+                 nonlinearity=F.relu,
                  last_wscale=1):
         self.n_input_channels = n_input_channels
         self.n_hidden_layers = n_hidden_layers
@@ -45,4 +47,24 @@ class FCVFunction(SingleModelVFunction):
                       [self.n_hidden_channels] * self.n_hidden_layers,
                       nonlinearity=nonlinearity,
                       last_wscale=last_wscale),
+        )
+
+
+class FCBNVFunction(SingleModelVFunction):
+
+    def __init__(self, n_input_channels, n_hidden_layers=0,
+                 n_hidden_channels=None,
+                 normalize_input=True,
+                 nonlinearity=F.relu,
+                 last_wscale=1):
+        self.n_input_channels = n_input_channels
+        self.n_hidden_layers = n_hidden_layers
+        self.n_hidden_channels = n_hidden_channels
+
+        super().__init__(
+            model=MLPBN(self.n_input_channels, 1,
+                        [self.n_hidden_channels] * self.n_hidden_layers,
+                        normalize_input=normalize_input,
+                        nonlinearity=nonlinearity,
+                        last_wscale=last_wscale),
         )

--- a/tests/agents_tests/test_a3c.py
+++ b/tests/agents_tests/test_a3c.py
@@ -102,7 +102,7 @@ class TestA3C(unittest.TestCase):
                 )
             else:
                 model = a3c.A3CSeparateModel(
-                    pi=policies.FCGaussianPolicy(  # todo:
+                    pi=policies.FCGaussianPolicy(
                         obs_space.low.size, action_space.low.size,
                         n_hidden_channels=n_hidden_channels,
                         n_hidden_layers=2,

--- a/tests/agents_tests/test_a3c.py
+++ b/tests/agents_tests/test_a3c.py
@@ -20,6 +20,7 @@ from chainerrl.experiments.train_agent_async import train_agent_async
 from chainerrl.optimizers import rmsprop_async
 from chainerrl import policies
 from chainerrl import v_function
+from chainerrl import v_functions
 
 
 @testing.parameterize(*(
@@ -27,12 +28,20 @@ from chainerrl import v_function
         't_max': [1, 2],
         'use_lstm': [False],
         'episodic': [True, False],
+        'use_bn': [False]
     }) +
     testing.product({
         't_max': [5],
         'use_lstm': [True, False],
         'episodic': [True, False],
-    })
+        'use_bn': [False]
+    }) +
+    [{
+        't_max': 1,
+        'use_lstm': False,
+        'episodic': False,
+        'use_bn': True
+    }]
 ))
 class TestA3C(unittest.TestCase):
 
@@ -45,8 +54,8 @@ class TestA3C(unittest.TestCase):
         self._test_abc(self.t_max, self.use_lstm, episodic=self.episodic)
 
     def test_abc_discrete_fast(self):
-        self._test_abc(self.t_max, self.use_lstm, episodic=self.episodic,
-                       steps=10, require_success=False)
+        self._test_abc(self.t_max, self.use_lstm, use_bn=self.use_bn,
+                       episodic=self.episodic, steps=10, require_success=False)
 
     @testing.attr.slow
     def test_abc_gaussian(self):
@@ -56,11 +65,11 @@ class TestA3C(unittest.TestCase):
 
     def test_abc_gaussian_fast(self):
         self._test_abc(self.t_max, self.use_lstm,
-                       discrete=False, episodic=self.episodic,
-                       steps=10, require_success=False)
+                       discrete=False, use_bn=self.use_bn,
+                       episodic=self.episodic, steps=10, require_success=False)
 
-    def _test_abc(self, t_max, use_lstm, discrete=True, episodic=True,
-                  steps=1000000, require_success=True):
+    def _test_abc(self, t_max, use_lstm, discrete=True, use_bn=False,
+                  episodic=True, steps=1000000, require_success=True):
 
         nproc = 8
 
@@ -78,7 +87,35 @@ class TestA3C(unittest.TestCase):
             return x
 
         n_hidden_channels = 20
-        if use_lstm:
+        if use_bn:
+            if discrete:
+                model = a3c.A3CSeparateModel(
+                    pi=policies.FCBNSoftmaxPolicy(
+                        obs_space.low.size, action_space.n,
+                        n_hidden_channels=n_hidden_channels,
+                        n_hidden_layers=2,
+                        min_prob=1e-1),
+                    v=v_functions.FCBNVFunction(
+                        obs_space.low.size,
+                        n_hidden_channels=n_hidden_channels,
+                        n_hidden_layers=2),
+                )
+            else:
+                model = a3c.A3CSeparateModel(
+                    pi=policies.FCGaussianPolicy(  # todo:
+                        obs_space.low.size, action_space.low.size,
+                        n_hidden_channels=n_hidden_channels,
+                        n_hidden_layers=2,
+                        bound_mean=True,
+                        min_action=action_space.low,
+                        max_action=action_space.high,
+                        min_var=0.1),
+                    v=v_functions.FCBNVFunction(
+                        obs_space.low.size,
+                        n_hidden_channels=n_hidden_channels,
+                        n_hidden_layers=2),
+                )
+        elif use_lstm:
             if discrete:
                 model = a3c.A3CSharedModel(
                     shared=L.LSTM(obs_space.low.size, n_hidden_channels),

--- a/tests/agents_tests/test_acer.py
+++ b/tests/agents_tests/test_acer.py
@@ -25,9 +25,11 @@ from chainerrl.envs.abc import ABC
 from chainerrl.experiments.train_agent_async import train_agent_async
 from chainerrl.optimizers import rmsprop_async
 from chainerrl import policies
-from chainerrl import q_function, q_functions
+from chainerrl import q_function
+from chainerrl import q_functions
 from chainerrl.replay_buffer import EpisodicReplayBuffer
-from chainerrl import v_function, v_functions
+from chainerrl import v_function
+from chainerrl import v_functions
 
 
 def extract_gradients_as_single_vector(link):
@@ -360,12 +362,13 @@ class TestACER(unittest.TestCase):
 
     @testing.attr.slow
     def test_abc(self):
-        self._test_abc(self.t_max, self.use_lstm, discrete=self.discrete, use_bn=self.use_bn,
-                       episodic=self.episodic)
+        self._test_abc(self.t_max, self.use_lstm, discrete=self.discrete,
+                       use_bn=self.use_bn, episodic=self.episodic)
 
     def test_abc_fast(self):
-        self._test_abc(self.t_max, self.use_lstm, discrete=self.discrete, use_bn=self.use_bn,
-                       episodic=self.episodic, steps=10, require_success=False)
+        self._test_abc(self.t_max, self.use_lstm, discrete=self.discrete,
+                       use_bn=self.use_bn, episodic=self.episodic,
+                       steps=10, require_success=False)
 
     def _test_abc(self, t_max, use_lstm, discrete=True, use_bn=False,
                   episodic=True, steps=1000000, require_success=True):

--- a/tests/agents_tests/test_acer.py
+++ b/tests/agents_tests/test_acer.py
@@ -401,7 +401,7 @@ class TestACER(unittest.TestCase):
                         n_hidden_layers=n_hidden_layers,
                         nonlinearity=nonlinearity,
                         min_prob=1e-1),
-                    q=q_functions.FCStateQFunctionWithDiscreteAction(  # todo
+                    q=q_functions.FCStateQFunctionWithDiscreteAction(
                         obs_space.low.size, action_space.n,
                         n_hidden_channels=n_hidden_channels,
                         n_hidden_layers=n_hidden_layers,
@@ -409,7 +409,7 @@ class TestACER(unittest.TestCase):
                 )
             else:
                 model = acer.ACERSDNSeparateModel(
-                    pi=policies.FCGaussianPolicy(  # todo
+                    pi=policies.FCGaussianPolicy(
                         obs_space.low.size, action_space.low.size,
                         n_hidden_channels=n_hidden_channels,
                         n_hidden_layers=n_hidden_layers,

--- a/tests/agents_tests/test_reinforce.py
+++ b/tests/agents_tests/test_reinforce.py
@@ -30,7 +30,7 @@ from chainerrl import policies
         'use_bn': [False]
     }) +
     testing.product({
-        'discrete': [True, False],
+        'discrete': [True],
         'use_lstm': [False],
         'batchsize': [5],
         'backward_separately': [True, False],
@@ -81,22 +81,11 @@ class TestREINFORCE(unittest.TestCase):
         n_hidden_layers = 1
         nonlinearity = F.leaky_relu
         if use_bn:
-            if discrete:
-                model = policies.FCBNSoftmaxPolicy(
-                    obs_space.low.size, action_space.n,
-                    n_hidden_channels=n_hidden_channels,
-                    n_hidden_layers=n_hidden_layers,
-                    nonlinearity=nonlinearity)
-            else:
-                model = policies.FCGaussianPolicy(  # todo
-                    obs_space.low.size, action_space.low.size,
-                    n_hidden_channels=n_hidden_channels,
-                    n_hidden_layers=n_hidden_layers,
-                    bound_mean=True,
-                    min_action=action_space.low,
-                    max_action=action_space.high,
-                    nonlinearity=nonlinearity,
-                )
+            model = policies.FCBNSoftmaxPolicy(
+                obs_space.low.size, action_space.n,
+                n_hidden_channels=n_hidden_channels,
+                n_hidden_layers=n_hidden_layers,
+                nonlinearity=nonlinearity)
         elif use_lstm:
             if discrete:
                 model = chainerrl.links.Sequence(


### PR DESCRIPTION
below agents seem to be fixed

- [x] a3c
- [x] acer
- [x] reinforce
