### PR TITLE
Fix QuadraticActionValue and add tests

### DIFF
--- a/chainerrl/action_value.py
+++ b/chainerrl/action_value.py
@@ -120,8 +120,14 @@ class QuadraticActionValue(ActionValue):
         self.mu = mu
         self.mat = mat
         self.v = v
-        self.min_action = self.xp.asarray(min_action, dtype=np.float32)
-        self.max_action = self.xp.asarray(max_action, dtype=np.float32)
+        if min_action is None:
+            self.min_action = None
+        else:
+            self.min_action = self.xp.asarray(min_action, dtype=np.float32)
+        if max_action is None:
+            self.max_action = None
+        else:
+            self.max_action = self.xp.asarray(max_action, dtype=np.float32)
 
         self.batch_size = self.mu.data.shape[0]
 

--- a/tests/test_action_value.py
+++ b/tests/test_action_value.py
@@ -62,7 +62,7 @@ class TestDiscreteActionValue(unittest.TestCase):
 
 
 class TestQuadraticActionValue(unittest.TestCase):
-    def test_unbounded(self):
+    def test_max_unbounded(self):
         n_batch = 7
         ndim_action = 3
         mu = np.random.randn(n_batch, ndim_action).astype(np.float32)
@@ -81,7 +81,7 @@ class TestQuadraticActionValue(unittest.TestCase):
 
         np.testing.assert_almost_equal(v_out, v)
 
-    def test_bounded(self):
+    def test_max_bounded(self):
         n_batch = 20
         ndim_action = 3
         mu = np.random.randn(n_batch, ndim_action).astype(np.float32)

--- a/tests/test_action_value.py
+++ b/tests/test_action_value.py
@@ -86,13 +86,16 @@ class TestQuadraticActionValue(unittest.TestCase):
             mu, mat, v, min_action, max_action)
         v_out = q_out.max.data
 
-        mu_is_allowed = (min_action < mu) * (mu < max_action)
-        mu_is_allowed = np.all(mu_is_allowed, axis=1)
-
         # If mu[i] is an valid action, v_out[i] should be v[i]
+        mu_is_allowed = np.all(
+            (min_action < mu) * (mu < max_action),
+            axis=1)
         np.testing.assert_almost_equal(v_out[mu_is_allowed], v[mu_is_allowed])
 
         # Otherwise, v_out[i] should be less than v[i]
+        mu_is_not_allowed = ~np.all(
+            (min_action - 1e-2 < mu) * (mu < max_action + 1e-2),
+            axis=1)
         np.testing.assert_array_less(
-            v_out[~mu_is_allowed],
-            v[~mu_is_allowed] + 1e-4)
+            v_out[mu_is_not_allowed],
+            v[mu_is_not_allowed])

--- a/tests/test_action_value.py
+++ b/tests/test_action_value.py
@@ -70,8 +70,16 @@ class TestQuadraticActionValue(unittest.TestCase):
             np.eye(ndim_action, dtype=np.float32)[None],
             (n_batch, ndim_action, ndim_action))
         v = np.random.randn(n_batch).astype(np.float32)
-        q_out = action_value.QuadraticActionValue(mu, mat, v)
-        np.testing.assert_almost_equal(q_out.max.data, v)
+        q_out = action_value.QuadraticActionValue(
+            chainer.Variable(mu),
+            chainer.Variable(mat),
+            chainer.Variable(v))
+
+        v_out = q_out.max
+        self.assertIsInstance(v_out, chainer.Variable)
+        v_out = v_out.data
+
+        np.testing.assert_almost_equal(v_out, v)
 
     def test_bounded(self):
         n_batch = 20
@@ -83,8 +91,14 @@ class TestQuadraticActionValue(unittest.TestCase):
         v = np.random.randn(n_batch).astype(np.float32)
         min_action, max_action = -1.3, 1.3
         q_out = action_value.QuadraticActionValue(
-            mu, mat, v, min_action, max_action)
-        v_out = q_out.max.data
+            chainer.Variable(mu),
+            chainer.Variable(mat),
+            chainer.Variable(v),
+            min_action, max_action)
+
+        v_out = q_out.max
+        self.assertIsInstance(v_out, chainer.Variable)
+        v_out = v_out.data
 
         # If mu[i] is an valid action, v_out[i] should be v[i]
         mu_is_allowed = np.all(


### PR DESCRIPTION
`QuadraticActionValue` called with `min_action=None` or `max_action=None` seems to have a bug.

Note:
```
>>> import numpy as np
>>> np.asarray(None, dtype=np.float32)
array(nan, dtype=float32)
```