### PR TITLE
Add documentation about recurrent models

### DIFF
--- a/chainerrl/recurrent.py
+++ b/chainerrl/recurrent.py
@@ -25,20 +25,43 @@ def unchain_backward(state):
 
 
 class Recurrent(with_metaclass(ABCMeta, object)):
-    """Interface of recurrent models."""
+    """Interface of recurrent and stateful models.
+
+    This is an interface of recurrent and stateful models. ChainerRL supports
+    recurrent neural network models as stateful models that implement this
+    interface.
+
+    To implement this interface, you need to implement three abstract methods
+    of it: get_state, set_state and reset_state.
+    """
 
     __state_stack = []
 
     @abstractmethod
     def get_state(self):
+        """Get a state of this model.
+
+        Returns:
+            Any object that represents a state of this model.
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def set_state(self, state):
+        """Overwrite this model's state with a given state.
+
+        Args:
+            state (object): Any object that represents a state of this model.
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def reset_state(self):
+        """Reset this model's state to the initial state.
+
+        For typical RL models, this method is expected to be called before
+        every episode.
+        """
         raise NotImplementedError()
 
     def unchain_backward(self):
@@ -55,7 +78,7 @@ class Recurrent(with_metaclass(ABCMeta, object)):
         self.__state_stack.append(self.get_state())
 
     def update_state(self, *args, **kwargs):
-        """Update its state as if self.__call__ is called.
+        """Update this model's state as if self.__call__ is called.
 
         Unlike __call__, stateless objects may do nothing.
         """
@@ -145,6 +168,25 @@ class RecurrentChainMixin(Recurrent):
 
 @contextlib.contextmanager
 def state_kept(link):
+    """Keeps the previous state of a given link.
+
+    This is a context manager that saves saves the current state of the link
+    before entering the context, and then restores the saved state after
+    escaping the context.
+
+    This will just ignore non-Recurrent links.
+
+    .. admonition:: Example
+       .. code-block:: python
+          # Suppose the link is in a state A
+          with state_kept(link):
+              # The link is still in a state A
+              y1 = link(x1)
+              # After evaluating the link, it may be in a different state
+              y2 = link(x2)
+          # After escaping from the context, the link is in a state A again
+          # because of the context manager
+    """
     if isinstance(link, Recurrent):
         link.push_and_keep_state()
         yield
@@ -155,6 +197,23 @@ def state_kept(link):
 
 @contextlib.contextmanager
 def state_reset(link):
+    """Reset the state while keeping the previous state of a given link.
+
+    This is a context manager that saves saves the current state of the link
+    and reset it before entering the context, and then restores the saved state
+    after escaping the context.
+
+    This will just ignore non-Recurrent links.
+
+    .. admonition:: Example
+       .. code-block:: python
+          # Suppose the link is in a state A
+          with state_kept(link):
+              # The link's state has been reset
+              y1 = link(x1)
+          # After escaping from the context, the link is in a state A again
+          # because of the context manager
+    """
     if isinstance(link, Recurrent):
         link.push_state()
         yield

--- a/chainerrl/recurrent.py
+++ b/chainerrl/recurrent.py
@@ -39,7 +39,7 @@ class Recurrent(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def get_state(self):
-        """Get a state of this model.
+        """Get the current state of this model.
 
         Returns:
             Any object that represents a state of this model.
@@ -48,7 +48,7 @@ class Recurrent(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def set_state(self, state):
-        """Overwrite this model's state with a given state.
+        """Overwrite the state of this model with a given state.
 
         Args:
             state (object): Any object that represents a state of this model.
@@ -57,7 +57,7 @@ class Recurrent(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def reset_state(self):
-        """Reset this model's state to the initial state.
+        """Reset the state of this model to the initial state.
 
         For typical RL models, this method is expected to be called before
         every episode.

--- a/chainerrl/recurrent.py
+++ b/chainerrl/recurrent.py
@@ -176,16 +176,22 @@ def state_kept(link):
 
     This will just ignore non-Recurrent links.
 
-    .. admonition:: Example
        .. code-block:: python
+
           # Suppose the link is in a state A
+          assert link.get_state() is A
+
           with state_kept(link):
               # The link is still in a state A
-              y1 = link(x1)
+              assert link.get_state() is A
+
               # After evaluating the link, it may be in a different state
-              y2 = link(x2)
+              y1 = link(x1)
+              assert link.get_state() is not A
+
           # After escaping from the context, the link is in a state A again
           # because of the context manager
+          assert link.get_state() is A
     """
     if isinstance(link, Recurrent):
         link.push_and_keep_state()
@@ -200,19 +206,27 @@ def state_reset(link):
     """Reset the state while keeping the previous state of a given link.
 
     This is a context manager that saves saves the current state of the link
-    and reset it before entering the context, and then restores the saved state
-    after escaping the context.
+    and reset it to the initial state before entering the context, and then
+    restores the saved state after escaping the context.
 
     This will just ignore non-Recurrent links.
 
-    .. admonition:: Example
        .. code-block:: python
-          # Suppose the link is in a state A
-          with state_kept(link):
-              # The link's state has been reset
+
+          # Suppose the link is in a non-initial state A
+          assert link.get_state() is A
+
+          with state_reset(link):
+              # The link's state has been reset to the initial state
+              assert link.get_state() is InitialState
+
+              # After evaluating the link, it may be in a different state
               y1 = link(x1)
+              assert link.get_state() is not InitialState
+
           # After escaping from the context, the link is in a state A again
           # because of the context manager
+          assert link.get_state() is A
     """
     if isinstance(link, Recurrent):
         link.push_state()

--- a/docs/recurrent.rst
+++ b/docs/recurrent.rst
@@ -1,0 +1,16 @@
+======================
+Using recurrent models
+======================
+
+Recurrent model interface
+=========================
+
+.. autoclass:: chainerrl.recurrent.Recurrent
+   :members:
+
+Utilities
+=========
+
+.. autoclass:: chainerrl.recurrent.state_kept
+
+.. autoclass:: chainerrl.recurrent.state_reset

--- a/docs/recurrent.rst
+++ b/docs/recurrent.rst
@@ -11,6 +11,6 @@ Recurrent model interface
 Utilities
 =========
 
-.. autoclass:: chainerrl.recurrent.state_kept
+.. autofunction:: chainerrl.recurrent.state_kept
 
-.. autoclass:: chainerrl.recurrent.state_reset
+.. autofunction:: chainerrl.recurrent.state_reset

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -9,3 +9,4 @@ API Reference
    agents
    distributions
    experiments
+   recurrent


### PR DESCRIPTION
Current documentation on recurrent models in ChainerRL is scarce. This PR will add a page dedicated to the recurrent model interface and utilities to the docs. The related docstrings are also improved.

This resolves #83 