### PR TITLE
Add gpus argument for chainerrl.misc.set_random_seed

### DIFF
--- a/chainerrl/misc/random_seed.py
+++ b/chainerrl/misc/random_seed.py
@@ -37,5 +37,5 @@ def set_random_seed(seed, gpus=()):
         if gpu >= 0:
             with chainer.cuda.get_device_from_id(gpu):
                 chainer.cuda.cupy.random.seed(seed)
-    # chainer.functions.n_step_rnn depends on CHAINER_SEED
+    # chainer.functions.n_step_rnn directly depends on CHAINER_SEED
     os.environ['CHAINER_SEED'] = str(seed)

--- a/chainerrl/misc/random_seed.py
+++ b/chainerrl/misc/random_seed.py
@@ -9,10 +9,33 @@ standard_library.install_aliases()
 import os
 import random
 
+import chainer
 import numpy as np
 
 
-def set_random_seed(seed):
+def set_random_seed(seed, gpus=()):
+    """Set a given random seed to ChainerRL's random sources.
+
+    This function sets a given random seed to random sources that ChainerRL
+    depends on so that ChainerRL can be deterministic. It is not responsible
+    for setting a random seed to environments ChainerRL is applied to.
+
+    Note that there's no guaranteed way to make all the computations done by
+    Chainer deterministic. See https://github.com/chainer/chainer/issues/4134.
+
+    Args:
+        seed (int): Random seed [0, 2 ** 32).
+        gpus (tuple of ints): GPU device IDs to use. Negative values are
+            ignored.
+    """
+    # ChainerRL depends on random
     random.seed(seed)
+    # ChainerRL depends on numpy.random
     np.random.seed(seed)
+    # ChainerRL depends on cupy.random for GPU computation
+    for gpu in gpus:
+        if gpu >= 0:
+            with chainer.cuda.get_device_from_id(gpu):
+                chainer.cuda.cupy.random.seed(seed)
+    # chainer.functions.n_step_rnn depends on CHAINER_SEED
     os.environ['CHAINER_SEED'] = str(seed)

--- a/tests/misc_tests/test_random_seed.py
+++ b/tests/misc_tests/test_random_seed.py
@@ -1,0 +1,54 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+from builtins import *  # NOQA
+standard_library.install_aliases()
+
+import random
+import unittest
+
+import chainer
+from chainer.testing import attr
+import numpy as np
+
+import chainerrl
+
+
+class TestSetRandomSeed(unittest.TestCase):
+
+    def test_random(self):
+        chainerrl.misc.set_random_seed(0)
+        seed0_0 = random.random()
+        chainerrl.misc.set_random_seed(1)
+        seed1_0 = random.random()
+        chainerrl.misc.set_random_seed(0)
+        seed0_1 = random.random()
+        chainerrl.misc.set_random_seed(1)
+        seed1_1 = random.random()
+        self.assertEqual(seed0_0, seed0_1)
+        self.assertEqual(seed1_0, seed1_1)
+        self.assertNotEqual(seed0_0, seed1_0)
+
+    def _test_xp_random(self, xp, gpus):
+        chainerrl.misc.set_random_seed(0, gpus=gpus)
+        seed0_0 = xp.random.rand()
+        chainerrl.misc.set_random_seed(1, gpus=gpus)
+        seed1_0 = xp.random.rand()
+        chainerrl.misc.set_random_seed(0, gpus=gpus)
+        seed0_1 = xp.random.rand()
+        chainerrl.misc.set_random_seed(1, gpus=gpus)
+        seed1_1 = xp.random.rand()
+        self.assertEqual(seed0_0, seed0_1)
+        self.assertEqual(seed1_0, seed1_1)
+        self.assertNotEqual(seed0_0, seed1_0)
+
+    def test_numpy_random(self):
+        self._test_xp_random(np, gpus=())
+        # It should ignore negative device IDs
+        self._test_xp_random(np, gpus=(-1,))
+
+    @attr.gpu
+    def test_cupy_random(self):
+        self._test_xp_random(chainer.cuda.cupy, gpus=(0,))


### PR DESCRIPTION
- Add `gpus` argument to `chainerrl.misc.set_random_seed` to set a seed of `cupy.random` as well as `random` and `numpy.random`.
- Add docstring and tests