### PR TITLE
show error message

### DIFF
--- a/chainerrl/misc/copy_param.py
+++ b/chainerrl/misc/copy_param.py
@@ -16,7 +16,9 @@ def copy_param(target_link, source_link):
         if target_params[param_name].data is None:
             raise TypeError(
                 'target_link parameter {} is None. Maybe the model params are '
-                'not initialized.'.format(param_name))
+                'not initialized.\nPlease try to forward dummy input beforehand'
+                ' to determine parameter shape of the model.'.format(
+                    param_name))
         target_params[param_name].data[:] = param.data
 
     # Copy Batch Normalization's statistics
@@ -35,7 +37,9 @@ def soft_copy_param(target_link, source_link, tau):
         if target_params[param_name].data is None:
             raise TypeError(
                 'target_link parameter {} is None. Maybe the model params are '
-                'not initialized.'.format(param_name))
+                'not initialized.\nPlease try to forward dummy input beforehand'
+                ' to determine parameter shape of the model.'.format(
+                    param_name))
         target_params[param_name].data[:] *= (1 - tau)
         target_params[param_name].data[:] += tau * param.data
 

--- a/chainerrl/misc/copy_param.py
+++ b/chainerrl/misc/copy_param.py
@@ -15,7 +15,7 @@ def copy_param(target_link, source_link):
     for param_name, param in source_link.namedparams():
         if target_params[param_name].data is None:
             raise TypeError(
-                'target_params of {} is None. Maybe the model params are '
+                'target_link parameter {} is None. Maybe the model params are '
                 'not initialized.'.format(param_name))
         target_params[param_name].data[:] = param.data
 
@@ -34,7 +34,7 @@ def soft_copy_param(target_link, source_link, tau):
     for param_name, param in source_link.namedparams():
         if target_params[param_name].data is None:
             raise TypeError(
-                'target_params of {} is None. Maybe the model params are '
+                'target_link parameter {} is None. Maybe the model params are '
                 'not initialized.'.format(param_name))
         target_params[param_name].data[:] *= (1 - tau)
         target_params[param_name].data[:] += tau * param.data

--- a/chainerrl/misc/copy_param.py
+++ b/chainerrl/misc/copy_param.py
@@ -16,8 +16,8 @@ def copy_param(target_link, source_link):
         if target_params[param_name].data is None:
             raise TypeError(
                 'target_link parameter {} is None. Maybe the model params are '
-                'not initialized.\nPlease try to forward dummy input beforehand'
-                ' to determine parameter shape of the model.'.format(
+                'not initialized.\nPlease try to forward dummy input '
+                'beforehand to determine parameter shape of the model.'.format(
                     param_name))
         target_params[param_name].data[:] = param.data
 
@@ -37,8 +37,8 @@ def soft_copy_param(target_link, source_link, tau):
         if target_params[param_name].data is None:
             raise TypeError(
                 'target_link parameter {} is None. Maybe the model params are '
-                'not initialized.\nPlease try to forward dummy input beforehand'
-                ' to determine parameter shape of the model.'.format(
+                'not initialized.\nPlease try to forward dummy input '
+                'beforehand to determine parameter shape of the model.'.format(
                     param_name))
         target_params[param_name].data[:] *= (1 - tau)
         target_params[param_name].data[:] += tau * param.data

--- a/chainerrl/misc/copy_param.py
+++ b/chainerrl/misc/copy_param.py
@@ -13,6 +13,10 @@ def copy_param(target_link, source_link):
     """Copy parameters of a link to another link."""
     target_params = dict(target_link.namedparams())
     for param_name, param in source_link.namedparams():
+        if target_params[param_name].data is None:
+            raise TypeError(
+                'target_params of {} is None. Maybe the model params are '
+                'not initialized.'.format(param_name))
         target_params[param_name].data[:] = param.data
 
     # Copy Batch Normalization's statistics
@@ -28,6 +32,10 @@ def soft_copy_param(target_link, source_link, tau):
     """Soft-copy parameters of a link to another link."""
     target_params = dict(target_link.namedparams())
     for param_name, param in source_link.namedparams():
+        if target_params[param_name].data is None:
+            raise TypeError(
+                'target_params of {} is None. Maybe the model params are '
+                'not initialized.'.format(param_name))
         target_params[param_name].data[:] *= (1 - tau)
         target_params[param_name].data[:] += tau * param.data
 

--- a/tests/misc_tests/test_copy_param.py
+++ b/tests/misc_tests/test_copy_param.py
@@ -32,6 +32,15 @@ class TestCopyParam(unittest.TestCase):
         self.assertEqual(a_out_new, b_out)
         self.assertEqual(b_out_new, b_out)
 
+    def test_copy_param_type_check(self):
+        a = L.Linear(None, 5)
+        b = L.Linear(1, 5)
+
+        with self.assertRaises(TypeError):
+            # Copy b's parameters to a, but since `a` parameter is not
+            # initialized, it should raise error.
+            copy_param.copy_param(a, b)
+
     def test_soft_copy_param(self):
         a = L.Linear(1, 5)
         b = L.Linear(1, 5)
@@ -50,3 +59,10 @@ class TestCopyParam(unittest.TestCase):
         np.testing.assert_almost_equal(
             a.W.data, np.full(a.W.data.shape, 0.595))
         np.testing.assert_almost_equal(b.W.data, np.full(b.W.data.shape, 1.0))
+
+    def test_soft_copy_param_type_check(self):
+        a = L.Linear(None, 5)
+        b = L.Linear(1, 5)
+
+        with self.assertRaises(TypeError):
+            copy_param.soft_copy_param(target_link=a, source_link=b, tau=0.1)


### PR DESCRIPTION
When we construct `QFunction`, and model parameter is not initialized (it happens when some Link is instantiated with `in_size=None`), `copy_param` will fail because the `target_link`'s `param` is `None`.

This PR is to show user-friendly error message to let the user know what is the cause of this error.

I'd like to get comment that what kind of message is better.

I'm not sure the performance degrade by checking this type error.