### PR TITLE
Fix PCL tests

### DIFF
--- a/tests/agents_tests/test_pcl.py
+++ b/tests/agents_tests/test_pcl.py
@@ -62,7 +62,7 @@ class TestPCL(unittest.TestCase):
     def test_abc_gaussian(self):
         self._test_abc(self.t_max, self.use_lstm,
                        discrete=False, episodic=self.episodic,
-                       steps=1000000)
+                       steps=100000)
 
     def test_abc_gaussian_fast(self):
         self._test_abc(self.t_max, self.use_lstm,
@@ -70,7 +70,7 @@ class TestPCL(unittest.TestCase):
                        steps=10, require_success=False)
 
     def _test_abc(self, t_max, use_lstm, discrete=True, episodic=True,
-                  steps=1000000, require_success=True):
+                  steps=100000, require_success=True):
 
         nproc = 8
 
@@ -100,7 +100,6 @@ class TestPCL(unittest.TestCase):
                         n_hidden_layers=n_hidden_layers,
                         nonlinearity=nonlinearity,
                         last_wscale=1e-2,
-                        min_prob=1e-1,
                     ),
                     v=v_function.FCVFunction(
                         n_hidden_channels,
@@ -142,7 +141,6 @@ class TestPCL(unittest.TestCase):
                         n_hidden_layers=n_hidden_layers,
                         nonlinearity=nonlinearity,
                         last_wscale=1e-2,
-                        min_prob=1e-1,
                     ),
                     v=v_function.FCVFunction(
                         obs_space.low.size,
@@ -215,7 +213,7 @@ class TestPCL(unittest.TestCase):
                 outdir=self.outdir,
                 steps=steps,
                 max_episode_len=2,
-                eval_interval=500,
+                eval_interval=200,
                 eval_n_runs=5,
                 successful_score=1)
 


### PR DESCRIPTION
Resolves #159 

It seems setting a minimum probability is harmful here.

After this PR, `test_pcl.py` succeeded 10 times in a row.

```
$ for i in `seq 10`; do nosetests -x tests/agents_tests/test_pcl.py; done
................................................................................................
----------------------------------------------------------------------
Ran 96 tests in 215.050s

OK
................................................................................................
----------------------------------------------------------------------
Ran 96 tests in 296.631s

OK
................................................................................................
----------------------------------------------------------------------
Ran 96 tests in 167.221s

OK
................................................................................................
----------------------------------------------------------------------
Ran 96 tests in 267.790s

OK
................................................................................................
----------------------------------------------------------------------
Ran 96 tests in 281.979s

OK
................................................................................................
----------------------------------------------------------------------
Ran 96 tests in 195.559s

OK
................................................................................................
----------------------------------------------------------------------
Ran 96 tests in 204.496s

OK
................................................................................................
----------------------------------------------------------------------
Ran 96 tests in 279.983s

OK
................................................................................................
----------------------------------------------------------------------
Ran 96 tests in 181.846s

OK
................................................................................................
----------------------------------------------------------------------
Ran 96 tests in 242.569s

OK
```