### PR TITLE
Add an option to set whether the agent is saved every time the score is improved

### DIFF
--- a/chainerrl/experiments/train_agent.py
+++ b/chainerrl/experiments/train_agent.py
@@ -90,11 +90,22 @@ def train_agent(agent, env, steps, outdir, max_episode_len=None,
     save_agent(agent, t, outdir, logger, suffix='_finish')
 
 
-def train_agent_with_evaluation(
-        agent, env, steps, eval_n_runs, eval_interval,
-        outdir, max_episode_len=None, step_offset=0, eval_explorer=None,
-        eval_max_episode_len=None, eval_env=None, successful_score=None,
-        step_hooks=[], logger=None):
+def train_agent_with_evaluation(agent,
+                                env,
+                                steps,
+                                eval_n_runs,
+                                eval_interval,
+                                outdir,
+                                max_episode_len=None,
+                                step_offset=0,
+                                eval_explorer=None,
+                                eval_max_episode_len=None,
+                                eval_env=None,
+                                successful_score=None,
+                                step_hooks=[],
+                                save_best_so_far_agent=True,
+                                logger=None,
+                                ):
     """Train an agent while regularly evaluating it.
 
     Args:
@@ -115,6 +126,9 @@ def train_agent_with_evaluation(
         step_hooks (list): List of callable objects that accepts
             (env, agent, step) as arguments. They are called every step.
             See chainerrl.experiments.hooks.
+        save_best_so_far_agent (bool): If set to True, after each evaluation,
+            if the score (= mean return of evaluation episodes) exceeds
+            the best-so-far score, the current agent is saved.
         logger (logging.Logger): Logger used in this function.
     """
 
@@ -135,7 +149,9 @@ def train_agent_with_evaluation(
                           explorer=eval_explorer,
                           env=eval_env,
                           step_offset=step_offset,
-                          logger=logger)
+                          save_best_so_far_agent=save_best_so_far_agent,
+                          logger=logger,
+                          )
 
     train_agent(
         agent, env, steps, outdir,

--- a/chainerrl/experiments/train_agent_async.py
+++ b/chainerrl/experiments/train_agent_async.py
@@ -135,7 +135,9 @@ def train_agent_async(outdir, processes, make_env,
                       agent=None,
                       make_agent=None,
                       global_step_hooks=[],
-                      logger=None):
+                      save_best_so_far_agent=True,
+                      logger=None,
+                      ):
     """Train agent asynchronously using multiprocessing.
 
     Either `agent` or `make_agent` must be specified.
@@ -159,6 +161,9 @@ def train_agent_async(outdir, processes, make_env,
         global_step_hooks (list): List of callable objects that accepts
             (env, agent, step) as arguments. They are called every global
             step. See chainerrl.experiments.hooks.
+        save_best_so_far_agent (bool): If set to True, after each evaluation,
+            if the score (= mean return of evaluation episodes) exceeds
+            the best-so-far score, the current agent is saved.
         logger (logging.Logger): Logger used in this function.
 
     Returns:
@@ -190,7 +195,9 @@ def train_agent_async(outdir, processes, make_env,
             max_episode_len=max_episode_len,
             step_offset=step_offset,
             explorer=eval_explorer,
-            logger=logger)
+            save_best_so_far_agent=save_best_so_far_agent,
+            logger=logger,
+        )
 
     def run_func(process_idx):
         random_seed.set_random_seed(process_idx)

--- a/tests/experiments_tests/test_evaluator.py
+++ b/tests/experiments_tests/test_evaluator.py
@@ -1,0 +1,145 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()
+
+import tempfile
+import unittest
+
+from chainer import testing
+import mock
+
+import chainerrl
+
+
+@testing.parameterize(
+    *testing.product({
+        'save_best_so_far_agent': [True, False],
+        'n_runs': [1, 2],
+    })
+)
+class TestEvaluator(unittest.TestCase):
+
+    def test_evaluate_if_necessary(self):
+        outdir = tempfile.mkdtemp()
+
+        agent = mock.Mock()
+        agent.act.return_value = 'action'
+        agent.get_statistics.return_value = []
+
+        env = mock.Mock()
+        env.reset.return_value = 'obs'
+        env.step.return_value = ('obs', 0, True, {})
+
+        evaluator = chainerrl.experiments.evaluator.Evaluator(
+            agent=agent,
+            env=env,
+            n_runs=self.n_runs,
+            eval_interval=3,
+            outdir=outdir,
+            max_episode_len=None,
+            explorer=None,
+            step_offset=0,
+            save_best_so_far_agent=self.save_best_so_far_agent,
+        )
+
+        evaluator.evaluate_if_necessary(t=1, episodes=1)
+        self.assertEqual(agent.act.call_count, 0)
+
+        evaluator.evaluate_if_necessary(t=2, episodes=2)
+        self.assertEqual(agent.act.call_count, 0)
+
+        # First evaluation
+        evaluator.evaluate_if_necessary(t=3, episodes=3)
+        self.assertEqual(agent.act.call_count, self.n_runs)
+        self.assertEqual(agent.stop_episode.call_count, self.n_runs)
+        if self.save_best_so_far_agent:
+            self.assertEqual(agent.save.call_count, 1)
+        else:
+            self.assertEqual(agent.save.call_count, 0)
+
+        # Second evaluation with the same score
+        evaluator.evaluate_if_necessary(t=6, episodes=6)
+        self.assertEqual(agent.act.call_count, 2 * self.n_runs)
+        self.assertEqual(agent.stop_episode.call_count, 2 * self.n_runs)
+        if self.save_best_so_far_agent:
+            self.assertEqual(agent.save.call_count, 1)
+        else:
+            self.assertEqual(agent.save.call_count, 0)
+
+        # Third evaluation with a better score
+        env.step.return_value = ('obs', 1, True, {})
+        evaluator.evaluate_if_necessary(t=9, episodes=9)
+        self.assertEqual(agent.act.call_count, 3 * self.n_runs)
+        self.assertEqual(agent.stop_episode.call_count, 3 * self.n_runs)
+        if self.save_best_so_far_agent:
+            self.assertEqual(agent.save.call_count, 2)
+        else:
+            self.assertEqual(agent.save.call_count, 0)
+
+
+@testing.parameterize(
+    *testing.product({
+        'save_best_so_far_agent': [True, False],
+        'n_runs': [1, 2],
+    })
+)
+class TestAsyncEvaluator(unittest.TestCase):
+
+    def test_evaluate_if_necessary(self):
+        outdir = tempfile.mkdtemp()
+
+        agent = mock.Mock()
+        agent.act.return_value = 'action'
+        agent.get_statistics.return_value = []
+
+        env = mock.Mock()
+        env.reset.return_value = 'obs'
+        env.step.return_value = ('obs', 0, True, {})
+
+        evaluator = chainerrl.experiments.evaluator.AsyncEvaluator(
+            n_runs=self.n_runs,
+            eval_interval=3,
+            outdir=outdir,
+            max_episode_len=None,
+            explorer=None,
+            step_offset=0,
+            save_best_so_far_agent=self.save_best_so_far_agent,
+        )
+
+        evaluator.evaluate_if_necessary(t=1, episodes=1, env=env, agent=agent)
+        self.assertEqual(agent.act.call_count, 0)
+
+        evaluator.evaluate_if_necessary(t=2, episodes=2, env=env, agent=agent)
+        self.assertEqual(agent.act.call_count, 0)
+
+        # First evaluation
+        evaluator.evaluate_if_necessary(t=3, episodes=3, env=env, agent=agent)
+        self.assertEqual(agent.act.call_count, self.n_runs)
+        self.assertEqual(agent.stop_episode.call_count, self.n_runs)
+        if self.save_best_so_far_agent:
+            self.assertEqual(agent.save.call_count, 1)
+        else:
+            self.assertEqual(agent.save.call_count, 0)
+
+        # Second evaluation with the same score
+        evaluator.evaluate_if_necessary(t=6, episodes=6, env=env, agent=agent)
+        self.assertEqual(agent.act.call_count, 2 * self.n_runs)
+        self.assertEqual(agent.stop_episode.call_count, 2 * self.n_runs)
+        if self.save_best_so_far_agent:
+            self.assertEqual(agent.save.call_count, 1)
+        else:
+            self.assertEqual(agent.save.call_count, 0)
+
+        # Third evaluation with a better score
+        env.step.return_value = ('obs', 1, True, {})
+        evaluator.evaluate_if_necessary(t=9, episodes=9, env=env, agent=agent)
+        self.assertEqual(agent.act.call_count, 3 * self.n_runs)
+        self.assertEqual(agent.stop_episode.call_count, 3 * self.n_runs)
+        if self.save_best_so_far_agent:
+            self.assertEqual(agent.save.call_count, 2)
+        else:
+            self.assertEqual(agent.save.call_count, 0)


### PR DESCRIPTION
- Currently, the agent is saved every time the score is improved in `train_agent_with_evaluation` and `train_agent_async`. This PR adds the `save_best_so_far_agent` option to disable it.
- Add docstrings and tests for `Evaluator` and `AsyncEvaluator`