### PR TITLE
[WIP] Fix on flake8 3.5.0

### DIFF
--- a/chainerrl/agents/ppo.py
+++ b/chainerrl/agents/ppo.py
@@ -138,7 +138,7 @@ class PPO(agent.AttributeSavingMixin, agent.Agent):
                 + (self.gamma * transition['nonterminal']
                    * transition['next_v_pred'])
                 - transition['v_pred']
-                )
+            )
             adv = td_err + self.gamma * self.lambd * adv
             transition['adv'] = adv
             transition['v_teacher'] = adv + transition['v_pred']
@@ -164,7 +164,7 @@ class PPO(agent.AttributeSavingMixin, agent.Agent):
                                            vs_pred_old - self.clip_eps_vf,
                                            vs_pred_old + self.clip_eps_vf)
                          - vs_teacher)
-                ))
+            ))
 
         loss_entropy = -F.mean(ent)
 
@@ -183,7 +183,7 @@ class PPO(agent.AttributeSavingMixin, agent.Agent):
             loss_policy
             + self.value_func_coef * loss_value_func
             + self.entropy_coef * loss_entropy
-            )
+        )
 
     def update(self):
         xp = self.xp
@@ -219,7 +219,7 @@ class PPO(agent.AttributeSavingMixin, agent.Agent):
                 advs=advs,
                 vs_teacher=xp.array(
                     [b['v_teacher'] for b in batch], dtype=xp.float32),
-                )
+            )
 
     def act_and_train(self, state, reward):
         if hasattr(self.model, 'obs_filter'):
@@ -289,4 +289,4 @@ class PPO(agent.AttributeSavingMixin, agent.Agent):
             ('average_loss_policy', self.average_loss_policy),
             ('average_loss_value_func', self.average_loss_value_func),
             ('average_loss_entropy', self.average_loss_entropy),
-            ]
+        ]

--- a/chainerrl/explorers/boltzmann.py
+++ b/chainerrl/explorers/boltzmann.py
@@ -31,7 +31,7 @@ class Boltzmann(chainerrl.explorer.Explorer):
         with chainer.no_backprop_mode():
             probs = chainer.cuda.to_cpu(
                 F.softmax(action_value.q_values / self.T).data).ravel()
-        return np.random.choice(np.arange(n_actions),  p=probs)
+        return np.random.choice(np.arange(n_actions), p=probs)
 
     def __repr__(self):
         return 'Boltzmann(T={})'.format(self.T)

--- a/examples/ale/train_dqn_ale.py
+++ b/examples/ale/train_dqn_ale.py
@@ -157,5 +157,6 @@ def main():
             outdir=args.outdir, eval_explorer=eval_explorer,
             eval_env=eval_env)
 
+
 if __name__ == '__main__':
     main()

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -127,5 +127,6 @@ def main():
             eval_explorer=explorer,
             global_step_hooks=[lr_decay_hook])
 
+
 if __name__ == '__main__':
     main()

--- a/examples/ale/train_ppo_ale.py
+++ b/examples/ale/train_ppo_ale.py
@@ -143,8 +143,8 @@ def main():
             step_hooks=[
                 lr_decay_hook,
                 clip_eps_decay_hook,
-                ],
-            )
+            ],
+        )
 
 
 if __name__ == '__main__':

--- a/examples/gym/train_ddpg_gym.py
+++ b/examples/gym/train_ddpg_gym.py
@@ -169,5 +169,6 @@ def main():
             outdir=args.outdir,
             max_episode_len=timestep_limit)
 
+
 if __name__ == '__main__':
     main()

--- a/examples/gym/train_ppo_gym.py
+++ b/examples/gym/train_ppo_gym.py
@@ -213,8 +213,8 @@ def main():
             step_hooks=[
                 lr_decay_hook,
                 clip_eps_decay_hook,
-                ],
-            )
+            ],
+        )
 
 
 if __name__ == '__main__':

--- a/tests/functions_tests/test_mellowmax.py
+++ b/tests/functions_tests/test_mellowmax.py
@@ -102,4 +102,5 @@ class TestMaximumEntropyMellowmax(unittest.TestCase):
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
The current check misses some new rules.
> "flake8 with hacking forces flake8 to be old (2.5.5) that uses pep8" https://github.com/chainer/chainer/pull/4097#issuecomment-351624573