### PR TITLE
Make tests check exit status of subprocesses

### DIFF
--- a/chainerrl/misc/async.py
+++ b/chainerrl/misc/async.py
@@ -133,10 +133,14 @@ def run_async(n_process, run_func):
 
     for process_idx, p in enumerate(processes):
         p.join()
-        if p.exitcode < 0:
+        if p.exitcode > 0:
             warnings.warn(
                 "Process #{} (pid={}) exited with nonzero status {}".format(
                     process_idx, p.pid, p.exitcode))
+        elif p.exitcode < 0:
+            warnings.warn(
+                "Process #{} (pid={}) was terminated by signal {}".format(
+                    process_idx, p.pid, -p.exitcode))
 
 
 def as_shared_objects(obj):

--- a/tests/agents_tests/test_a3c.py
+++ b/tests/agents_tests/test_a3c.py
@@ -10,6 +10,7 @@ import logging
 import os
 import tempfile
 import unittest
+import warnings
 
 from chainer import links as L
 from chainer import testing
@@ -147,13 +148,15 @@ class TestA3C(unittest.TestCase):
 
         max_episode_len = None if episodic else 2
 
-        train_agent_async(
-            outdir=self.outdir, processes=nproc, make_env=make_env,
-            agent=agent, steps=steps,
-            max_episode_len=max_episode_len,
-            eval_interval=500,
-            eval_n_runs=5,
-            successful_score=1)
+        with warnings.catch_warnings(record=True) as warns:
+            train_agent_async(
+                outdir=self.outdir, processes=nproc, make_env=make_env,
+                agent=agent, steps=steps,
+                max_episode_len=max_episode_len,
+                eval_interval=500,
+                eval_n_runs=5,
+                successful_score=1)
+            assert len(warns) == 0, warns[0]
 
         # The agent returned by train_agent_async is not guaranteed to be
         # successful because parameters could be modified by other processes

--- a/tests/agents_tests/test_acer.py
+++ b/tests/agents_tests/test_acer.py
@@ -11,6 +11,7 @@ import logging
 import os
 import tempfile
 import unittest
+import warnings
 
 import chainer
 from chainer import functions as F
@@ -473,13 +474,15 @@ class TestACER(unittest.TestCase):
 
         max_episode_len = None if episodic else 2
 
-        train_agent_async(
-            outdir=self.outdir, processes=nproc, make_env=make_env,
-            agent=agent, steps=steps,
-            max_episode_len=max_episode_len,
-            eval_interval=500,
-            eval_n_runs=5,
-            successful_score=1)
+        with warnings.catch_warnings(record=True) as warns:
+            train_agent_async(
+                outdir=self.outdir, processes=nproc, make_env=make_env,
+                agent=agent, steps=steps,
+                max_episode_len=max_episode_len,
+                eval_interval=500,
+                eval_n_runs=5,
+                successful_score=1)
+            assert len(warns) == 0, warns[0]
 
         # The agent returned by train_agent_async is not guaranteed to be
         # successful because parameters could be modified by other processes

--- a/tests/agents_tests/test_nsq.py
+++ b/tests/agents_tests/test_nsq.py
@@ -10,6 +10,7 @@ import logging
 import os
 import tempfile
 import unittest
+import warnings
 
 from chainer import testing
 import numpy as np
@@ -98,14 +99,16 @@ class TestNSQ(unittest.TestCase):
                            gamma=0.9, i_target=100,
                            explorer=explorer)
 
-        agent = train_agent_async(
-            outdir=self.outdir, processes=nproc, make_env=make_env,
-            make_agent=make_agent, steps=steps,
-            max_episode_len=5,
-            eval_interval=500,
-            eval_n_runs=5,
-            successful_score=1,
-        )
+        with warnings.catch_warnings(record=True) as warns:
+            agent = train_agent_async(
+                outdir=self.outdir, processes=nproc, make_env=make_env,
+                make_agent=make_agent, steps=steps,
+                max_episode_len=5,
+                eval_interval=500,
+                eval_n_runs=5,
+                successful_score=1,
+            )
+            assert len(warns) == 0, warns[0]
 
         # The agent returned by train_agent_async is not guaranteed to be
         # successful because parameters could be modified by other processes

--- a/tests/agents_tests/test_pcl.py
+++ b/tests/agents_tests/test_pcl.py
@@ -10,6 +10,7 @@ import logging
 import os
 import tempfile
 import unittest
+import warnings
 
 from chainer import functions as F
 from chainer import links as L
@@ -191,13 +192,15 @@ class TestPCL(unittest.TestCase):
                         act_deterministically=True)
 
         if self.train_async:
-            chainerrl.experiments.train_agent_async(
-                outdir=self.outdir, processes=nproc, make_env=make_env,
-                agent=agent, steps=steps,
-                max_episode_len=2,
-                eval_interval=200,
-                eval_n_runs=5,
-                successful_score=1)
+            with warnings.catch_warnings(record=True) as warns:
+                chainerrl.experiments.train_agent_async(
+                    outdir=self.outdir, processes=nproc, make_env=make_env,
+                    agent=agent, steps=steps,
+                    max_episode_len=2,
+                    eval_interval=200,
+                    eval_n_runs=5,
+                    successful_score=1)
+                assert len(warns) == 0, warns[0]
             # The agent returned by train_agent_async is not guaranteed to be
             # successful because parameters could be modified by other
             # processes after success. Thus here the successful model is loaded


### PR DESCRIPTION
- Warn nonzero exit status. (see also #194)
- Check warnings in tests using `train_agent_async`.