### PR TITLE
make ReplayBuffer.load() compatible with v0.2.0.

### DIFF
--- a/chainerrl/replay_buffer.py
+++ b/chainerrl/replay_buffer.py
@@ -10,6 +10,7 @@ standard_library.install_aliases()
 from abc import ABCMeta
 from abc import abstractmethod
 from abc import abstractproperty
+import collections
 
 import numpy as np
 import six.moves.cPickle as pickle
@@ -153,7 +154,8 @@ class ReplayBuffer(AbstractReplayBuffer):
     def load(self, filename):
         with open(filename, 'rb') as f:
             self.memory = pickle.load(f)
-        if not isinstance(self.memory, RandomAccessQueue):
+        if isinstance(self.memory, collections.deque):
+            # Load v0.2
             self.memory = RandomAccessQueue(
                 self.memory, maxlen=self.memory.maxlen)
 
@@ -288,8 +290,13 @@ class EpisodicReplayBuffer(AbstractEpisodicReplayBuffer):
         if isinstance(memory, tuple):
             self.memory, self.episodic_memory = memory
         else:
+            # Load v0.2
+            # FIXME: The code works with EpisodicReplayBuffer
+            # but not with PrioritizedEpisodicReplayBuffer
             self.memory = RandomAccessQueue(memory)
             self.episodic_memory = RandomAccessQueue()
+
+            # Recover episodic_memory with best effort.
             episode = []
             for item in self.memory:
                 episode.append(item)


### PR DESCRIPTION
If we use ReplayBuffer that loaded a buffer saved with v0.2.0, an error will occur because deque doesn't have sample() method.
This PR makes load() methods of ReplayBuffer and EpisodicReplayBuffer compatible with buffer saved with v0.2.0.