### PR TITLE
Align act and act_and_train's signature to the Agent interface

### DIFF
--- a/chainerrl/agents/a3c.py
+++ b/chainerrl/agents/a3c.py
@@ -245,9 +245,9 @@ class A3C(agent.AttributeSavingMixin, agent.AsyncAgent):
 
         self.t_start = self.t
 
-    def act_and_train(self, state, reward):
+    def act_and_train(self, obs, reward):
 
-        statevar = self.batch_states([state], np, self.phi)
+        statevar = self.batch_states([obs], np, self.phi)
 
         self.past_rewards[self.t - 1] = reward
 

--- a/chainerrl/agents/acer.py
+++ b/chainerrl/agents/acer.py
@@ -611,9 +611,9 @@ class ACER(agent.AttributeSavingMixin, agent.AsyncAgent):
 
         self.init_history_data_for_online_update()
 
-    def act_and_train(self, state, reward):
+    def act_and_train(self, obs, reward):
 
-        statevar = np.expand_dims(self.phi(state), 0)
+        statevar = np.expand_dims(self.phi(obs), 0)
 
         self.past_rewards[self.t - 1] = reward
 
@@ -658,13 +658,13 @@ class ACER(agent.AttributeSavingMixin, agent.AsyncAgent):
                 state=self.last_state,
                 action=self.last_action,
                 reward=reward,
-                next_state=state,
+                next_state=obs,
                 next_action=action,
                 is_state_terminal=False,
                 mu=self.last_action_distrib,
             )
 
-        self.last_state = state
+        self.last_state = obs
         self.last_action = action
         self.last_action_distrib = action_distrib.copy()
 

--- a/chainerrl/agents/ddpg.py
+++ b/chainerrl/agents/ddpg.py
@@ -299,11 +299,11 @@ class DDPG(AttributeSavingMixin, Agent):
                 actor_loss += self.compute_actor_loss(batch)
             self.actor_optimizer.update(lambda: actor_loss / max_epi_len)
 
-    def act_and_train(self, state, reward):
+    def act_and_train(self, obs, reward):
 
         self.logger.debug('t:%s r:%s', self.t, reward)
 
-        greedy_action = self.act(state)
+        greedy_action = self.act(obs)
         action = self.explorer.select_action(self.t, lambda: greedy_action)
         self.t += 1
 
@@ -318,21 +318,21 @@ class DDPG(AttributeSavingMixin, Agent):
                 state=self.last_state,
                 action=self.last_action,
                 reward=reward,
-                next_state=state,
+                next_state=obs,
                 next_action=action,
                 is_state_terminal=False)
 
-        self.last_state = state
+        self.last_state = obs
         self.last_action = action
 
         self.replay_updater.update_if_necessary(self.t)
 
         return self.last_action
 
-    def act(self, state):
+    def act(self, obs):
 
         with chainer.using_config('train', False):
-            s = self.batch_states([state], self.xp, self.phi)
+            s = self.batch_states([obs], self.xp, self.phi)
             action = self.policy(s).sample()
             # Q is not needed here, but log it just for information
             q = self.q_function(s, action)

--- a/chainerrl/agents/dqn.py
+++ b/chainerrl/agents/dqn.py
@@ -370,11 +370,11 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
                 self.model(batch_x).q_values))
             return q_values
 
-    def act(self, state):
+    def act(self, obs):
         with chainer.using_config('train', False):
             with chainer.no_backprop_mode():
                 action_value = self.model(
-                    self.batch_states([state], self.xp, self.phi))
+                    self.batch_states([obs], self.xp, self.phi))
                 q = float(action_value.max.data)
                 action = cuda.to_cpu(action_value.greedy_actions.data)[0]
 
@@ -385,12 +385,12 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
         self.logger.debug('t:%s q:%s action_value:%s', self.t, q, action_value)
         return action
 
-    def act_and_train(self, state, reward):
+    def act_and_train(self, obs, reward):
 
         with chainer.using_config('train', False):
             with chainer.no_backprop_mode():
                 action_value = self.model(
-                    self.batch_states([state], self.xp, self.phi))
+                    self.batch_states([obs], self.xp, self.phi))
                 q = float(action_value.max.data)
                 greedy_action = cuda.to_cpu(action_value.greedy_actions.data)[
                     0]
@@ -416,11 +416,11 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
                 state=self.last_state,
                 action=self.last_action,
                 reward=reward,
-                next_state=state,
+                next_state=obs,
                 next_action=action,
                 is_state_terminal=False)
 
-        self.last_state = state
+        self.last_state = obs
         self.last_action = action
 
         self.replay_updater.update_if_necessary(self.t)

--- a/chainerrl/agents/pcl.py
+++ b/chainerrl/agents/pcl.py
@@ -378,9 +378,9 @@ class PCL(agent.AttributeSavingMixin, agent.AsyncAgent):
 
         self.init_history_data_for_online_update()
 
-    def act_and_train(self, state, reward):
+    def act_and_train(self, obs, reward):
 
-        statevar = self.batch_states([state], self.xp, self.phi)
+        statevar = self.batch_states([obs], self.xp, self.phi)
 
         if self.last_state is not None:
             self.past_rewards[self.t - 1] = reward
@@ -423,13 +423,13 @@ class PCL(agent.AttributeSavingMixin, agent.AsyncAgent):
                 state=self.last_state,
                 action=self.last_action,
                 reward=reward,
-                next_state=state,
+                next_state=obs,
                 next_action=action,
                 is_state_terminal=False,
                 mu=self.last_action_distrib,
             )
 
-        self.last_state = state
+        self.last_state = obs
         self.last_action = action
         self.last_action_distrib = action_distrib.copy()
 

--- a/chainerrl/agents/pgt.py
+++ b/chainerrl/agents/pgt.py
@@ -204,11 +204,11 @@ class PGT(AttributeSavingMixin, Agent):
         self.critic_optimizer.update(compute_critic_loss)
         self.actor_optimizer.update(compute_actor_loss)
 
-    def act_and_train(self, state, reward):
+    def act_and_train(self, obs, reward):
 
         self.logger.debug('t:%s r:%s', self.t, reward)
 
-        greedy_action = self.act(state)
+        greedy_action = self.act(obs)
         action = self.explorer.select_action(self.t, lambda: greedy_action)
         self.t += 1
 
@@ -223,21 +223,21 @@ class PGT(AttributeSavingMixin, Agent):
                 state=self.last_state,
                 action=self.last_action,
                 reward=reward,
-                next_state=state,
+                next_state=obs,
                 next_action=action,
                 is_state_terminal=False)
 
-        self.last_state = state
+        self.last_state = obs
         self.last_action = action
 
         self.replay_updater.update_if_necessary(self.t)
 
         return self.last_action
 
-    def act(self, state):
+    def act(self, obs):
 
         with chainer.using_config('train', False):
-            s = self.batch_states([state], self.xp, self.phi)
+            s = self.batch_states([obs], self.xp, self.phi)
             if self.act_deterministically:
                 action = self.policy(s).most_probable
             else:

--- a/chainerrl/agents/ppo.py
+++ b/chainerrl/agents/ppo.py
@@ -221,13 +221,13 @@ class PPO(agent.AttributeSavingMixin, agent.Agent):
                     [b['v_teacher'] for b in batch], dtype=xp.float32),
                 )
 
-    def act_and_train(self, state, reward):
+    def act_and_train(self, obs, reward):
         if hasattr(self.model, 'obs_filter'):
             xp = self.xp
-            b_state = batch_states([state], xp, self.phi)
+            b_state = batch_states([obs], xp, self.phi)
             self.model.obs_filter.experience(b_state)
 
-        action, v = self._act(state)
+        action, v = self._act(obs)
 
         # Update stats
         self.average_v += (
@@ -240,18 +240,18 @@ class PPO(agent.AttributeSavingMixin, agent.Agent):
                 'action': self.last_action,
                 'reward': reward,
                 'v_pred': self.last_v,
-                'next_state': state,
+                'next_state': obs,
                 'next_v_pred': v,
                 'nonterminal': 1.0})
-        self.last_state = state
+        self.last_state = obs
         self.last_action = action
         self.last_v = v
 
         self._train()
         return action
 
-    def act(self, state):
-        action, v = self._act(state)
+    def act(self, obs):
+        action, v = self._act(obs)
 
         # Update stats
         self.average_v += (


### PR DESCRIPTION
#229 Change function signatures in agents implementing the Agent interface so the argument name become consistent.

Tested with `pytest -m 'not slow'` and `./test_examples.sh 0`