### PR TITLE
Support dtype arg of spaces.Box

### DIFF
--- a/chainerrl/envs/abc.py
+++ b/chainerrl/envs/abc.py
@@ -33,14 +33,16 @@ class ABC(env.Env):
         # (s_0, ..., s_N) + terminal state + offset
         self.n_dim_obs = self.size + 1 + self.n_max_offset
         self.observation_space = spaces.Box(
-            low=np.asarray([-np.inf] * self.n_dim_obs, dtype=np.float32),
-            high=np.asarray([np.inf] * self.n_dim_obs, dtype=np.float32))
+            low=-np.inf, high=np.inf,
+            shape=(self.n_dim_obs,), dtype=np.float32,
+        )
         if discrete:
             self.action_space = spaces.Discrete(self.size)
         else:
             self.action_space = spaces.Box(
-                low=-np.ones(self.size, dtype=np.float32),
-                high=np.ones(self.size, dtype=np.float32))
+                low=-1.0, high=1.0,
+                shape=(self.size,), dtype=np.float32,
+            )
 
     def observe(self):
         state_vec = np.zeros((self.n_dim_obs,), dtype=np.float32)

--- a/chainerrl/envs/ale.py
+++ b/chainerrl/envs/ale.py
@@ -108,7 +108,9 @@ class ALE(env.Env):
 
         self.action_space = spaces.Discrete(len(self.legal_actions))
         one_screen_observation_space = spaces.Box(
-            low=0, high=255, shape=(84, 84))
+            low=0, high=255,
+            shape=(84, 84), dtype=np.uint8,
+        )
         self.observation_space = spaces.Tuple(
             [one_screen_observation_space] * n_last_screens)
 

--- a/chainerrl/spaces.py
+++ b/chainerrl/spaces.py
@@ -1,5 +1,42 @@
-# This module is just an alias to gym.spaces except that you don't need to
-# call gym.undo_logger_setup().
+# This module makes spaces in gym backward compatibile.
+# Also you don't need to call gym.undo_logger_setup().
+try:
+    from packaging import version
+except ImportError:
+    from pip._vendor.packaging import version
+
 import gym
-gym.undo_logger_setup()
-from gym.spaces import *  # NOQA
+import numpy as np
+
+
+try:
+    gym_version_string = gym.__version__
+except AttributeError:
+    import pkg_resources
+    gym_version_string = pkg_resources.get_distribution("gym").version
+
+gym_version = version.parse(gym_version_string)
+
+
+def _as_dtype(x, dtype):
+    if np.isscalar(x):
+        return dtype.type(x)
+    else:
+        return x.astype(dtype)
+
+
+if gym_version >= version.parse('0.9.6'):
+    from gym.spaces import *  # NOQA
+else:
+    gym.undo_logger_setup()
+    from gym.spaces import *  # NOQA
+
+    class Box(gym.spaces.Box):
+        """Box space with the newer (gym>=0.9.6) interface"""
+
+        def __init__(self, low=None, high=None, shape=None, dtype=None):
+            if dtype is not None:
+                dtype = np.dtype(dtype)
+                low = _as_dtype(low, dtype)
+                high = _as_dtype(high, dtype)
+            super().__init__(dtype.type(low), dtype.type(high), shape)


### PR DESCRIPTION
gym 0.9.6 added `dtype` arg to `spaces.Box`.
The PR supports the newer interface in a backward-compatible way.
The fix in `chainerrl.envs` removes the warnings `WARN: gym.spaces.Box autodetected dtype as <` ... `>. Please provide explicit dtype.`.