### PR TITLE
Improve random seed setting in ALE examples

### DIFF
--- a/examples/ale/train_a3c_ale.py
+++ b/examples/ale/train_a3c_ale.py
@@ -97,8 +97,8 @@ def main():
     # Set different random seeds for different subprocesses.
     # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].
     # If seed=1 and processes=4, subprocess seeds are [4, 5, 6, 7].
-    assert (args.seed + 1) * args.processes < 2 ** 31
     process_seeds = np.arange(args.processes) + args.seed * args.processes
+    assert process_seeds.max() < 2 ** 31
 
     args.outdir = experiments.prepare_output_dir(args, args.outdir)
     print('Output files are saved in {}'.format(args.outdir))

--- a/examples/ale/train_a3c_ale.py
+++ b/examples/ale/train_a3c_ale.py
@@ -69,7 +69,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('processes', type=int)
     parser.add_argument('rom', type=str)
-    parser.add_argument('--seed', type=int, default=None)
+    parser.add_argument('--seed', type=int, default=0,
+                        help='Random seed [0, 2 ** 31)')
     parser.add_argument('--outdir', type=str, default=None)
     parser.add_argument('--use-sdl', action='store_true')
     parser.add_argument('--t-max', type=int, default=5)
@@ -88,11 +89,18 @@ def main():
     parser.set_defaults(use_lstm=False)
     args = parser.parse_args()
 
-    if args.seed is not None:
-        misc.set_random_seed(args.seed)
+    # Set a random seed used in ChainerRL.
+    # If you use more than one processes, the results will be no longer
+    # deterministic even with the same random seed.
+    misc.set_random_seed(args.seed)
+
+    # Set different random seeds for different subprocesses.
+    # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].
+    # If seed=1 and processes=4, subprocess seeds are [4, 5, 6, 7].
+    assert (args.seed + 1) * args.processes < 2 ** 31
+    process_seeds = np.arange(args.processes) + args.seed * args.processes
 
     args.outdir = experiments.prepare_output_dir(args, args.outdir)
-
     print('Output files are saved in {}'.format(args.outdir))
 
     n_actions = ale.ALE(args.rom).number_of_actions
@@ -123,8 +131,12 @@ def main():
         agent.load(args.load)
 
     def make_env(process_idx, test):
+        # Use different random seeds for train and test envs
+        process_seed = process_seeds[process_idx]
+        env_seed = 2 ** 31 - 1 - process_seed if test else process_seed
         env = ale.ALE(args.rom, use_sdl=args.use_sdl,
-                      treat_life_lost_as_terminal=not test)
+                      treat_life_lost_as_terminal=not test,
+                      seed=env_seed)
         if not test:
             misc.env_modifiers.make_reward_clipped(env, -1, 1)
         return env


### PR DESCRIPTION
Merge #234 first.

This PR improves default random seed settings in `examples/ale/train_dqn_ale.py` and `examples/ale/train_a3c_ale.py` so that they are deterministic by default.

If this is merged, then I'll update other examples as well in another PR.