### PR TITLE
Improve random seed setting for all examples

### DIFF
--- a/examples/ale/train_acer_ale.py
+++ b/examples/ale/train_acer_ale.py
@@ -13,6 +13,7 @@ os.environ['OMP_NUM_THREADS'] = '1'
 
 import chainer
 from chainer import links as L
+import numpy as np
 
 from chainerrl.action_value import DiscreteActionValue
 from chainerrl.agents import acer
@@ -36,7 +37,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('processes', type=int)
     parser.add_argument('rom', type=str)
-    parser.add_argument('--seed', type=int, default=None)
+    parser.add_argument('--seed', type=int, default=0,
+                        help='Random seed [0, 2 ** 31)')
     parser.add_argument('--outdir', type=str, default=None)
     parser.add_argument('--use-sdl', action='store_true')
     parser.add_argument('--t-max', type=int, default=5)
@@ -57,11 +59,18 @@ def main():
     parser.set_defaults(use_lstm=False)
     args = parser.parse_args()
 
-    if args.seed is not None:
-        misc.set_random_seed(args.seed)
+    # Set a random seed used in ChainerRL.
+    # If you use more than one processes, the results will be no longer
+    # deterministic even with the same random seed.
+    misc.set_random_seed(args.seed)
+
+    # Set different random seeds for different subprocesses.
+    # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].
+    # If seed=1 and processes=4, subprocess seeds are [4, 5, 6, 7].
+    process_seeds = np.arange(args.processes) + args.seed * args.processes
+    assert process_seeds.max() < 2 ** 31
 
     args.outdir = experiments.prepare_output_dir(args, args.outdir)
-
     print('Output files are saved in {}'.format(args.outdir))
 
     n_actions = ale.ALE(args.rom).number_of_actions
@@ -104,11 +113,14 @@ def main():
         agent.load(args.load)
 
     def make_env(process_idx, test):
+        # Use different random seeds for train and test envs
+        process_seed = process_seeds[process_idx]
+        env_seed = 2 ** 31 - 1 - process_seed if test else process_seed
         env = ale.ALE(args.rom, use_sdl=args.use_sdl,
-                      treat_life_lost_as_terminal=not test)
+                      treat_life_lost_as_terminal=not test,
+                      seed=env_seed)
         if not test:
             misc.env_modifiers.make_reward_clipped(env, -1, 1)
-
         return env
 
     if args.demo:

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -8,6 +8,7 @@ standard_library.install_aliases()
 
 import argparse
 import os
+import random
 
 # This prevents numpy from using multiple threads
 os.environ['OMP_NUM_THREADS'] = '1'
@@ -31,7 +32,7 @@ from dqn_phi import dqn_phi
 def main():
 
     import logging
-    # logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.DEBUG)
 
     parser = argparse.ArgumentParser()
     parser.add_argument('processes', type=int)

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -8,12 +8,12 @@ standard_library.install_aliases()
 
 import argparse
 import os
-import random
 
 # This prevents numpy from using multiple threads
 os.environ['OMP_NUM_THREADS'] = '1'
 
 from chainer import links as L
+import numpy as np
 
 from chainerrl.action_value import DiscreteActionValue
 from chainerrl.agents import nsq
@@ -36,7 +36,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('processes', type=int)
     parser.add_argument('rom', type=str)
-    parser.add_argument('--seed', type=int, default=None)
+    parser.add_argument('--seed', type=int, default=0,
+                        help='Random seed [0, 2 ** 31)')
     parser.add_argument('--lr', type=float, default=7e-4)
     parser.add_argument('--steps', type=int, default=8 * 10 ** 7)
     parser.add_argument('--use-sdl', action='store_true', default=False)
@@ -50,16 +51,27 @@ def main():
     parser.add_argument('--load', type=str, default=None)
     args = parser.parse_args()
 
-    if args.seed is not None:
-        misc.set_random_seed(args.seed)
+    # Set a random seed used in ChainerRL.
+    # If you use more than one processes, the results will be no longer
+    # deterministic even with the same random seed.
+    misc.set_random_seed(args.seed)
+
+    # Set different random seeds for different subprocesses.
+    # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].
+    # If seed=1 and processes=4, subprocess seeds are [4, 5, 6, 7].
+    process_seeds = np.arange(args.processes) + args.seed * args.processes
+    assert process_seeds.max() < 2 ** 31
 
     args.outdir = experiments.prepare_output_dir(args, args.outdir)
-
     print('Output files are saved in {}'.format(args.outdir))
 
     def make_env(process_idx, test):
+        # Use different random seeds for train and test envs
+        process_seed = process_seeds[process_idx]
+        env_seed = 2 ** 31 - 1 - process_seed if test else process_seed
         env = ale.ALE(args.rom, use_sdl=args.use_sdl,
-                      treat_life_lost_as_terminal=not test)
+                      treat_life_lost_as_terminal=not test,
+                      seed=env_seed)
         if not test:
             misc.env_modifiers.make_reward_clipped(env, -1, 1)
         return env
@@ -126,6 +138,7 @@ def main():
             eval_interval=args.eval_interval,
             eval_explorer=explorer,
             global_step_hooks=[lr_decay_hook])
+
 
 if __name__ == '__main__':
     main()

--- a/examples/ale/train_ppo_ale.py
+++ b/examples/ale/train_ppo_ale.py
@@ -77,10 +77,6 @@ def main():
     # Set a random seed used in ChainerRL.
     misc.set_random_seed(args.seed, gpus=(args.gpu,))
 
-    # Set different random seeds for train and test envs.
-    train_seed = args.seed
-    test_seed = 2 ** 31 - 1 - args.seed
-
     args.outdir = experiments.prepare_output_dir(args, args.outdir)
     print('Output files are saved in {}'.format(args.outdir))
 
@@ -106,7 +102,7 @@ def main():
 
     def make_env(test):
         # Use different random seeds for train and test envs
-        env_seed = test_seed if test else train_seed
+        env_seed = 2 ** 31 - 1 - args.seed if test else args.seed
         env = ale.ALE(args.rom, use_sdl=args.use_sdl,
                       treat_life_lost_as_terminal=not test,
                       seed=env_seed)

--- a/examples/gym/train_a3c_gym.py
+++ b/examples/gym/train_a3c_gym.py
@@ -26,6 +26,7 @@ import chainer
 from chainer import functions as F
 from chainer import links as L
 import gym
+gym.undo_logger_setup()
 import gym.wrappers
 import numpy as np
 
@@ -105,7 +106,8 @@ def main():
     parser.add_argument('--env', type=str, default='CartPole-v0')
     parser.add_argument('--arch', type=str, default='FFSoftmax',
                         choices=('FFSoftmax', 'FFMellowmax', 'LSTMGaussian'))
-    parser.add_argument('--seed', type=int, default=None)
+    parser.add_argument('--seed', type=int, default=0,
+                        help='Random seed [0, 2 ** 32)')
     parser.add_argument('--outdir', type=str, default=None)
     parser.add_argument('--t-max', type=int, default=5)
     parser.add_argument('--beta', type=float, default=1e-2)
@@ -124,15 +126,27 @@ def main():
     parser.add_argument('--monitor', action='store_true')
     args = parser.parse_args()
 
-    logging.getLogger().setLevel(args.logger_level)
+    logging.basicConfig(level=args.logger_level)
 
-    if args.seed is not None:
-        misc.set_random_seed(args.seed)
+    # Set a random seed used in ChainerRL.
+    # If you use more than one processes, the results will be no longer
+    # deterministic even with the same random seed.
+    misc.set_random_seed(args.seed)
+
+    # Set different random seeds for different subprocesses.
+    # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].
+    # If seed=1 and processes=4, subprocess seeds are [4, 5, 6, 7].
+    process_seeds = np.arange(args.processes) + args.seed * args.processes
+    assert process_seeds.max() < 2 ** 32
 
     args.outdir = experiments.prepare_output_dir(args, args.outdir)
 
     def make_env(process_idx, test):
         env = gym.make(args.env)
+        # Use different random seeds for train and test envs
+        process_seed = int(process_seeds[process_idx])
+        env_seed = 2 ** 32 - 1 - process_seed if test else process_seed
+        env.seed(env_seed)
         if args.monitor and process_idx == 0:
             env = gym.wrappers.Monitor(env, args.outdir)
         # Scale rewards observed by agents

--- a/examples/gym/train_acer_gym.py
+++ b/examples/gym/train_acer_gym.py
@@ -43,7 +43,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('processes', type=int)
     parser.add_argument('--env', type=str, default='CartPole-v0')
-    parser.add_argument('--seed', type=int, default=None)
+    parser.add_argument('--seed', type=int, default=0,
+                        help='Random seed [0, 2 ** 32)')
     parser.add_argument('--outdir', type=str, default=None)
     parser.add_argument('--t-max', type=int, default=50)
     parser.add_argument('--n-times-replay', type=int, default=4)
@@ -71,13 +72,25 @@ def main():
 
     logging.basicConfig(level=args.logger_level)
 
-    if args.seed is not None:
-        misc.set_random_seed(args.seed)
+    # Set a random seed used in ChainerRL.
+    # If you use more than one processes, the results will be no longer
+    # deterministic even with the same random seed.
+    misc.set_random_seed(args.seed)
+
+    # Set different random seeds for different subprocesses.
+    # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].
+    # If seed=1 and processes=4, subprocess seeds are [4, 5, 6, 7].
+    process_seeds = np.arange(args.processes) + args.seed * args.processes
+    assert process_seeds.max() < 2 ** 32
 
     args.outdir = experiments.prepare_output_dir(args, args.outdir)
 
     def make_env(process_idx, test):
         env = gym.make(args.env)
+        # Use different random seeds for train and test envs
+        process_seed = int(process_seeds[process_idx])
+        env_seed = 2 ** 32 - 1 - process_seed if test else process_seed
+        env.seed(env_seed)
         if args.monitor and process_idx == 0:
             env = gym.wrappers.Monitor(env, args.outdir)
         # Scale rewards observed by agents

--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -45,7 +45,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--outdir', type=str, default='dqn_out')
     parser.add_argument('--env', type=str, default='Pendulum-v0')
-    parser.add_argument('--seed', type=int, default=None)
+    parser.add_argument('--seed', type=int, default=0,
+                        help='Random seed [0, 2 ** 32)')
     parser.add_argument('--gpu', type=int, default=0)
     parser.add_argument('--final-exploration-steps',
                         type=int, default=10 ** 4)
@@ -73,31 +74,34 @@ def main():
     parser.add_argument('--reward-scale-factor', type=float, default=1e-3)
     args = parser.parse_args()
 
+    # Set a random seed used in ChainerRL
+    misc.set_random_seed(args.seed, gpus=(args.gpu,))
+
     args.outdir = experiments.prepare_output_dir(
         args, args.outdir, argv=sys.argv)
     print('Output files are saved in {}'.format(args.outdir))
 
-    if args.seed is not None:
-        misc.set_random_seed(args.seed)
-
     def clip_action_filter(a):
         return np.clip(a, action_space.low, action_space.high)
 
-    def make_env(for_eval):
+    def make_env(test):
         env = gym.make(args.env)
+        # Use different random seeds for train and test envs
+        env_seed = 2 ** 32 - 1 - args.seed if test else args.seed
+        env.seed(env_seed)
         if args.monitor:
             env = gym.wrappers.Monitor(env, args.outdir)
         if isinstance(env.action_space, spaces.Box):
             misc.env_modifiers.make_action_filtered(env, clip_action_filter)
-        if not for_eval:
+        if not test:
             misc.env_modifiers.make_reward_filtered(
                 env, lambda x: x * args.reward_scale_factor)
-        if ((args.render_eval and for_eval) or
-                (args.render_train and not for_eval)):
+        if ((args.render_eval and test) or
+                (args.render_train and not test)):
             misc.env_modifiers.make_rendered(env)
         return env
 
-    env = make_env(for_eval=False)
+    env = make_env(test=False)
     timestep_limit = env.spec.tags.get(
         'wrapper_config.TimeLimit.max_episode_steps')
     obs_space = env.observation_space
@@ -171,7 +175,7 @@ def main():
     if args.load:
         agent.load(args.load)
 
-    eval_env = make_env(for_eval=True)
+    eval_env = make_env(test=True)
 
     if args.demo:
         eval_stats = experiments.eval_performance(

--- a/examples/gym/train_ppo_gym.py
+++ b/examples/gym/train_ppo_gym.py
@@ -18,6 +18,7 @@ import argparse
 import chainer
 from chainer import functions as F
 import gym
+gym.undo_logger_setup()
 import gym.wrappers
 import numpy as np
 
@@ -104,7 +105,8 @@ def main():
                                  'FFGaussian'))
     parser.add_argument('--normalize-obs', action='store_true')
     parser.add_argument('--bound-mean', action='store_true')
-    parser.add_argument('--seed', type=int, default=None)
+    parser.add_argument('--seed', type=int, default=0,
+                        help='Random seed [0, 2 ** 32)')
     parser.add_argument('--outdir', type=str, default=None)
     parser.add_argument('--steps', type=int, default=10 ** 6)
     parser.add_argument('--eval-interval', type=int, default=10000)
@@ -125,15 +127,18 @@ def main():
     parser.add_argument('--entropy-coef', type=float, default=0.0)
     args = parser.parse_args()
 
-    logging.getLogger().setLevel(args.logger_level)
+    logging.basicConfig(level=args.logger_level)
 
-    if args.seed is not None:
-        misc.set_random_seed(args.seed)
+    # Set a random seed used in ChainerRL
+    misc.set_random_seed(args.seed, gpus=(args.gpu,))
 
     args.outdir = experiments.prepare_output_dir(args, args.outdir)
 
     def make_env(test):
         env = gym.make(args.env)
+        # Use different random seeds for train and test envs
+        env_seed = 2 ** 32 - 1 - args.seed if test else args.seed
+        env.seed(env_seed)
         if args.monitor:
             env = gym.wrappers.Monitor(env, args.outdir)
         # Scale rewards observed by agents


### PR DESCRIPTION
in the same way as #239 

- ALE accepts `[0,2**31)`, so ALE examples use `[0,2**31)`.
- Although gym envs accepts broader range of values, numpy.random.seed accepts `[0,2**32)` as a integer, so gym examples use `[0,2**32)`.
- Logger outputs of some examples were invisible, so I changed their logger settings.