### PR TITLE
Set outdir to results and add help strings

### DIFF
--- a/examples/ale/train_a3c_ale.py
+++ b/examples/ale/train_a3c_ale.py
@@ -71,7 +71,9 @@ def main():
     parser.add_argument('rom', type=str)
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed [0, 2 ** 31)')
-    parser.add_argument('--outdir', type=str, default=None)
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
     parser.add_argument('--use-sdl', action='store_true')
     parser.add_argument('--t-max', type=int, default=5)
     parser.add_argument('--max-episode-len', type=int, default=10000)

--- a/examples/ale/train_acer_ale.py
+++ b/examples/ale/train_acer_ale.py
@@ -39,7 +39,9 @@ def main():
     parser.add_argument('rom', type=str)
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed [0, 2 ** 31)')
-    parser.add_argument('--outdir', type=str, default=None)
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
     parser.add_argument('--use-sdl', action='store_true')
     parser.add_argument('--t-max', type=int, default=5)
     parser.add_argument('--replay-start-size', type=int, default=10000)

--- a/examples/ale/train_dqn_ale.py
+++ b/examples/ale/train_dqn_ale.py
@@ -68,7 +68,9 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument('rom', type=str)
-    parser.add_argument('--outdir', type=str, default=None)
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed [0, 2 ** 31)')
     parser.add_argument('--gpu', type=int, default=0)

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -44,7 +44,9 @@ def main():
     parser.add_argument('--use-sdl', action='store_true', default=False)
     parser.add_argument('--final-exploration-frames',
                         type=int, default=4 * 10 ** 6)
-    parser.add_argument('--outdir', type=str, default='nsq_output')
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
     parser.add_argument('--profile', action='store_true')
     parser.add_argument('--eval-interval', type=int, default=10 ** 6)
     parser.add_argument('--eval-n-runs', type=int, default=10)

--- a/examples/ale/train_ppo_ale.py
+++ b/examples/ale/train_ppo_ale.py
@@ -50,7 +50,9 @@ def main():
     parser.add_argument('--gpu', type=int, default=0)
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed [0, 2 ** 31)')
-    parser.add_argument('--outdir', type=str, default=None)
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
     parser.add_argument('--use-sdl', action='store_true')
     parser.add_argument('--max-episode-len', type=int, default=10000)
     parser.add_argument('--profile', action='store_true')

--- a/examples/gym/train_a3c_gym.py
+++ b/examples/gym/train_a3c_gym.py
@@ -108,7 +108,9 @@ def main():
                         choices=('FFSoftmax', 'FFMellowmax', 'LSTMGaussian'))
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed [0, 2 ** 32)')
-    parser.add_argument('--outdir', type=str, default=None)
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
     parser.add_argument('--t-max', type=int, default=5)
     parser.add_argument('--beta', type=float, default=1e-2)
     parser.add_argument('--profile', action='store_true')

--- a/examples/gym/train_acer_gym.py
+++ b/examples/gym/train_acer_gym.py
@@ -45,7 +45,9 @@ def main():
     parser.add_argument('--env', type=str, default='CartPole-v0')
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed [0, 2 ** 32)')
-    parser.add_argument('--outdir', type=str, default=None)
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
     parser.add_argument('--t-max', type=int, default=50)
     parser.add_argument('--n-times-replay', type=int, default=4)
     parser.add_argument('--n-hidden-channels', type=int, default=100)

--- a/examples/gym/train_ddpg_gym.py
+++ b/examples/gym/train_ddpg_gym.py
@@ -30,7 +30,9 @@ def main():
     logging.basicConfig(level=logging.DEBUG)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--outdir', type=str, default='out')
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
     parser.add_argument('--env', type=str, default='Humanoid-v1')
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed [0, 2 ** 32)')

--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -44,7 +44,9 @@ def main():
     logging.basicConfig(level=logging.DEBUG)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--outdir', type=str, default='dqn_out')
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
     parser.add_argument('--env', type=str, default='Pendulum-v0')
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed [0, 2 ** 32)')

--- a/examples/gym/train_pcl_gym.py
+++ b/examples/gym/train_pcl_gym.py
@@ -47,7 +47,9 @@ def main():
     parser.add_argument('--env', type=str, default='CartPole-v0')
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed [0, 2 ** 32)')
-    parser.add_argument('--outdir', type=str, default=None)
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
     parser.add_argument('--batchsize', type=int, default=10)
     parser.add_argument('--rollout-len', type=int, default=10)
     parser.add_argument('--n-hidden-channels', type=int, default=100)

--- a/examples/gym/train_ppo_gym.py
+++ b/examples/gym/train_ppo_gym.py
@@ -107,7 +107,9 @@ def main():
     parser.add_argument('--bound-mean', action='store_true')
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed [0, 2 ** 32)')
-    parser.add_argument('--outdir', type=str, default=None)
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
     parser.add_argument('--steps', type=int, default=10 ** 6)
     parser.add_argument('--eval-interval', type=int, default=10000)
     parser.add_argument('--eval-n-runs', type=int, default=10)

--- a/examples/gym/train_reinforce_gym.py
+++ b/examples/gym/train_reinforce_gym.py
@@ -42,7 +42,9 @@ def main():
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed [0, 2 ** 32)')
     parser.add_argument('--gpu', type=int, default=0)
-    parser.add_argument('--outdir', type=str, default='results')
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
     parser.add_argument('--beta', type=float, default=1e-4)
     parser.add_argument('--batchsize', type=int, default=10)
     parser.add_argument('--steps', type=int, default=10 ** 5)


### PR DESCRIPTION
to make outdir settings consistent across the examples.

The default directory and the help string is the same as those of `examples/gym/train_trpo_gym.py`.