### PR TITLE
except both Exception and KeyboardInterrupt

### DIFF
--- a/chainerrl/experiments/train_agent.py
+++ b/chainerrl/experiments/train_agent.py
@@ -81,7 +81,7 @@ def train_agent(agent, env, steps, outdir, max_episode_len=None,
                 r = 0
                 done = False
 
-    except Exception:
+    except (Exception, KeyboardInterrupt):
         # Save the current model before being killed
         save_agent(agent, t, outdir, logger, suffix='_except')
         raise

--- a/chainerrl/experiments/train_agent_async.py
+++ b/chainerrl/experiments/train_agent_async.py
@@ -90,7 +90,7 @@ def train_loop(process_idx, env, agent, steps, outdir, counter,
                 if global_t > steps or training_done.value:
                     break
 
-    except KeyboardInterrupt:
+    except (Exception, KeyboardInterrupt):
         if process_idx == 0:
             # Save the current model before being killed
             dirname = os.path.join(outdir, '{}_except'.format(global_t))


### PR DESCRIPTION
In experiments/train_agent.py, line 84, it handles only Exception. But in experiments/train_agent_async.py, it handles only KeyboardInterrupt. I think these should handle both.