### PR TITLE
Update to hacking 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - pip install jupyter
   - pip install atari_py>=0.1.1
   - pip install autopep8
-  - pip install "hacking<1.1"
+  - pip install hacking
   - pip install coveralls
   - python setup.py develop
   - python -c "import numpy; numpy.show_config()"

--- a/chainerrl/action_value.py
+++ b/chainerrl/action_value.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
 from future.utils import with_metaclass
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/chainerrl/agent.py
+++ b/chainerrl/agent.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/chainerrl/agents/a3c.py
+++ b/chainerrl/agents/a3c.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import copy
 from logging import getLogger

--- a/chainerrl/agents/acer.py
+++ b/chainerrl/agents/acer.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import contextlib
 import copy

--- a/chainerrl/agents/al.py
+++ b/chainerrl/agents/al.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 from chainer import functions as F

--- a/chainerrl/agents/categorical_dqn.py
+++ b/chainerrl/agents/categorical_dqn.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 import chainer.functions as F

--- a/chainerrl/agents/ddpg.py
+++ b/chainerrl/agents/ddpg.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 from builtins import *  # NOQA
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import copy
 from logging import getLogger

--- a/chainerrl/agents/double_dqn.py
+++ b/chainerrl/agents/double_dqn.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 

--- a/chainerrl/agents/double_pal.py
+++ b/chainerrl/agents/double_pal.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 from chainer import functions as F

--- a/chainerrl/agents/dpp.py
+++ b/chainerrl/agents/dpp.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/chainerrl/agents/dqn.py
+++ b/chainerrl/agents/dqn.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import copy
 from logging import getLogger

--- a/chainerrl/agents/nsq.py
+++ b/chainerrl/agents/nsq.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import copy
 from logging import getLogger

--- a/chainerrl/agents/pal.py
+++ b/chainerrl/agents/pal.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 from chainer import functions as F

--- a/chainerrl/agents/pcl.py
+++ b/chainerrl/agents/pcl.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import copy
 from logging import getLogger

--- a/chainerrl/agents/pgt.py
+++ b/chainerrl/agents/pgt.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 from builtins import *  # NOQA
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import copy
 from logging import getLogger

--- a/chainerrl/agents/ppo.py
+++ b/chainerrl/agents/ppo.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import copy
 

--- a/chainerrl/agents/reinforce.py
+++ b/chainerrl/agents/reinforce.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from logging import getLogger
 import warnings

--- a/chainerrl/agents/residual_dqn.py
+++ b/chainerrl/agents/residual_dqn.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import chainer.functions as F
 
 from chainerrl.agents.dqn import DQN

--- a/chainerrl/agents/sarsa.py
+++ b/chainerrl/agents/sarsa.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from chainerrl.agents import dqn
 

--- a/chainerrl/agents/trpo.py
+++ b/chainerrl/agents/trpo.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import collections
 import itertools

--- a/chainerrl/distribution.py
+++ b/chainerrl/distribution.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/chainerrl/env.py
+++ b/chainerrl/env.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 from future.utils import with_metaclass
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/chainerrl/envs/abc.py
+++ b/chainerrl/envs/abc.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import numpy as np
 

--- a/chainerrl/envs/ale.py
+++ b/chainerrl/envs/ale.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import collections
 import os
 import sys

--- a/chainerrl/experiments/evaluator.py
+++ b/chainerrl/experiments/evaluator.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import logging
 import multiprocessing as mp

--- a/chainerrl/experiments/hooks.py
+++ b/chainerrl/experiments/hooks.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/chainerrl/experiments/prepare_output_dir.py
+++ b/chainerrl/experiments/prepare_output_dir.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import argparse
 import datetime

--- a/chainerrl/experiments/train_agent.py
+++ b/chainerrl/experiments/train_agent.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import logging
 import os

--- a/chainerrl/experiments/train_agent_async.py
+++ b/chainerrl/experiments/train_agent_async.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import logging
 import multiprocessing as mp

--- a/chainerrl/explorer.py
+++ b/chainerrl/explorer.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/chainerrl/explorers/additive_gaussian.py
+++ b/chainerrl/explorers/additive_gaussian.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import numpy as np
 

--- a/chainerrl/explorers/additive_ou.py
+++ b/chainerrl/explorers/additive_ou.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from logging import getLogger
 

--- a/chainerrl/explorers/boltzmann.py
+++ b/chainerrl/explorers/boltzmann.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 from chainer import functions as F

--- a/chainerrl/explorers/epsilon_greedy.py
+++ b/chainerrl/explorers/epsilon_greedy.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from logging import getLogger
 

--- a/chainerrl/explorers/greedy.py
+++ b/chainerrl/explorers/greedy.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from chainerrl import explorer
 

--- a/chainerrl/functions/bound_by_tanh.py
+++ b/chainerrl/functions/bound_by_tanh.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 from chainer import cuda

--- a/chainerrl/functions/invert_gradients.py
+++ b/chainerrl/functions/invert_gradients.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from chainer import cuda
 from chainer import function

--- a/chainerrl/functions/lower_triangular_matrix.py
+++ b/chainerrl/functions/lower_triangular_matrix.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from chainer import cuda
 from chainer import function

--- a/chainerrl/functions/scale_grad.py
+++ b/chainerrl/functions/scale_grad.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import numpy
 
 import chainer

--- a/chainerrl/links/dqn_head.py
+++ b/chainerrl/links/dqn_head.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import chainer
 from chainer import functions as F
 from chainer import links as L

--- a/chainerrl/links/empirical_normalization.py
+++ b/chainerrl/links/empirical_normalization.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 import numpy as np

--- a/chainerrl/links/mlp.py
+++ b/chainerrl/links/mlp.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 from chainer import functions as F

--- a/chainerrl/links/mlp_bn.py
+++ b/chainerrl/links/mlp_bn.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 from chainer import functions as F

--- a/chainerrl/links/sequence.py
+++ b/chainerrl/links/sequence.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 

--- a/chainerrl/misc/async.py
+++ b/chainerrl/misc/async.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import multiprocessing as mp
 import warnings

--- a/chainerrl/misc/collections.py
+++ b/chainerrl/misc/collections.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import itertools
 

--- a/chainerrl/misc/conjugate_gradient.py
+++ b/chainerrl/misc/conjugate_gradient.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 

--- a/chainerrl/misc/copy_param.py
+++ b/chainerrl/misc/copy_param.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from chainer import links as L
 

--- a/chainerrl/misc/draw_computational_graph.py
+++ b/chainerrl/misc/draw_computational_graph.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import subprocess
 

--- a/chainerrl/misc/env_modifiers.py
+++ b/chainerrl/misc/env_modifiers.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 from builtins import *  # NOQA
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import numpy as np
 

--- a/chainerrl/misc/init_like_torch.py
+++ b/chainerrl/misc/init_like_torch.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 from chainer import links as L
 import numpy as np
 

--- a/chainerrl/misc/is_return_code_zero.py
+++ b/chainerrl/misc/is_return_code_zero.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import os
 import subprocess

--- a/chainerrl/misc/makedirs.py
+++ b/chainerrl/misc/makedirs.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import os
 import six

--- a/chainerrl/misc/prioritized.py
+++ b/chainerrl/misc/prioritized.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import numpy as np
 

--- a/chainerrl/misc/random.py
+++ b/chainerrl/misc/random.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import numpy as np
 

--- a/chainerrl/misc/random_seed.py
+++ b/chainerrl/misc/random_seed.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import os
 import random

--- a/chainerrl/misc/reward_filter.py
+++ b/chainerrl/misc/reward_filter.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 
 class NormalizedRewardFilter(object):

--- a/chainerrl/optimizers/nonbias_weight_decay.py
+++ b/chainerrl/optimizers/nonbias_weight_decay.py
@@ -5,7 +5,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 from chainer import cuda
 
 

--- a/chainerrl/optimizers/rmsprop_async.py
+++ b/chainerrl/optimizers/rmsprop_async.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from chainer import cuda
 from chainer import optimizer

--- a/chainerrl/policies/deterministic_policy.py
+++ b/chainerrl/policies/deterministic_policy.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from logging import getLogger
 logger = getLogger(__name__)

--- a/chainerrl/policies/deterministic_policy.py
+++ b/chainerrl/policies/deterministic_policy.py
@@ -7,7 +7,6 @@ from future import standard_library
 standard_library.install_aliases()  # NOQA
 
 from logging import getLogger
-logger = getLogger(__name__)
 
 import chainer
 from chainer import functions as F
@@ -20,6 +19,9 @@ from chainerrl.links.mlp import MLP
 from chainerrl.links.mlp_bn import MLPBN
 from chainerrl.policy import Policy
 from chainerrl.recurrent import RecurrentChainMixin
+
+
+logger = getLogger(__name__)
 
 
 class ContinuousDeterministicPolicy(

--- a/chainerrl/policies/gaussian_policy.py
+++ b/chainerrl/policies/gaussian_policy.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import abstractmethod
 from logging import getLogger

--- a/chainerrl/policies/gaussian_policy.py
+++ b/chainerrl/policies/gaussian_policy.py
@@ -8,7 +8,6 @@ standard_library.install_aliases()  # NOQA
 
 from abc import abstractmethod
 from logging import getLogger
-logger = getLogger(__name__)
 
 import chainer
 from chainer import functions as F
@@ -20,6 +19,9 @@ from chainerrl.functions.bound_by_tanh import bound_by_tanh
 from chainerrl.initializers import LeCunNormal
 from chainerrl import links
 from chainerrl.policy import Policy
+
+
+logger = getLogger(__name__)
 
 
 class GaussianPolicy(Policy):

--- a/chainerrl/policies/mellowmax_policy.py
+++ b/chainerrl/policies/mellowmax_policy.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from logging import getLogger
 logger = getLogger(__name__)

--- a/chainerrl/policies/mellowmax_policy.py
+++ b/chainerrl/policies/mellowmax_policy.py
@@ -7,12 +7,14 @@ from future import standard_library
 standard_library.install_aliases()  # NOQA
 
 from logging import getLogger
-logger = getLogger(__name__)
 
 import chainer
 
 from chainerrl import distribution
 from chainerrl.policy import Policy
+
+
+logger = getLogger(__name__)
 
 
 class MellowmaxPolicy(chainer.Chain, Policy):

--- a/chainerrl/policies/softmax_policy.py
+++ b/chainerrl/policies/softmax_policy.py
@@ -7,7 +7,6 @@ from future import standard_library
 standard_library.install_aliases()  # NOQA
 
 from logging import getLogger
-logger = getLogger(__name__)
 
 import chainer
 from chainer import functions as F
@@ -15,6 +14,9 @@ from chainer import functions as F
 from chainerrl import distribution
 from chainerrl.links.mlp import MLP
 from chainerrl.policy import Policy
+
+
+logger = getLogger(__name__)
 
 
 class SoftmaxPolicy(chainer.Chain, Policy):

--- a/chainerrl/policies/softmax_policy.py
+++ b/chainerrl/policies/softmax_policy.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from logging import getLogger
 logger = getLogger(__name__)

--- a/chainerrl/policy.py
+++ b/chainerrl/policy.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import abstractmethod
 from logging import getLogger

--- a/chainerrl/q_function.py
+++ b/chainerrl/q_function.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/chainerrl/q_functions/dueling_dqn.py
+++ b/chainerrl/q_functions/dueling_dqn.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 from chainer import functions as F

--- a/chainerrl/q_functions/state_action_q_functions.py
+++ b/chainerrl/q_functions/state_action_q_functions.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 from chainer import functions as F

--- a/chainerrl/q_functions/state_q_functions.py
+++ b/chainerrl/q_functions/state_q_functions.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 from chainer import cuda

--- a/chainerrl/recurrent.py
+++ b/chainerrl/recurrent.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
 from future.utils import with_metaclass
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/chainerrl/replay_buffer.py
+++ b/chainerrl/replay_buffer.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
 from future.utils import with_metaclass
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/chainerrl/v_function.py
+++ b/chainerrl/v_function.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/chainerrl/v_functions/v_functions.py
+++ b/chainerrl/v_functions/v_functions.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 from chainer import functions as F

--- a/examples/ale/dqn_phi.py
+++ b/examples/ale/dqn_phi.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import numpy as np
 

--- a/examples/ale/train_a3c_ale.py
+++ b/examples/ale/train_a3c_ale.py
@@ -9,7 +9,7 @@ import argparse
 import os
 
 # Prevent numpy from using multiple threads
-os.environ['OMP_NUM_THREADS'] = '1'
+os.environ['OMP_NUM_THREADS'] = '1'  # NOQA
 
 import chainer
 from chainer import links as L

--- a/examples/ale/train_a3c_ale.py
+++ b/examples/ale/train_a3c_ale.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import argparse
 import os
 

--- a/examples/ale/train_acer_ale.py
+++ b/examples/ale/train_acer_ale.py
@@ -9,7 +9,7 @@ import argparse
 import os
 
 # Prevent numpy from using multiple threads
-os.environ['OMP_NUM_THREADS'] = '1'
+os.environ['OMP_NUM_THREADS'] = '1'  # NOQA
 
 import chainer
 from chainer import links as L

--- a/examples/ale/train_acer_ale.py
+++ b/examples/ale/train_acer_ale.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import argparse
 import os
 

--- a/examples/ale/train_categorical_dqn_ale.py
+++ b/examples/ale/train_categorical_dqn_ale.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import argparse
 import os
 

--- a/examples/ale/train_dqn_ale.py
+++ b/examples/ale/train_dqn_ale.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import argparse
 import os
 

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -11,7 +11,7 @@ import os
 import random
 
 # This prevents numpy from using multiple threads
-os.environ['OMP_NUM_THREADS'] = '1'
+os.environ['OMP_NUM_THREADS'] = '1'  # NOQA
 
 from chainer import links as L
 import numpy as np

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import argparse
 import os

--- a/examples/ale/train_ppo_ale.py
+++ b/examples/ale/train_ppo_ale.py
@@ -40,7 +40,7 @@ class A3CFF(chainer.ChainList, A3CModel):
 def main():
 
     # Prevent numpy from using multiple threads
-    os.environ['OMP_NUM_THREADS'] = '1'
+    os.environ['OMP_NUM_THREADS'] = '1'  # NOQA
 
     import logging
     logging.basicConfig(level=logging.DEBUG)

--- a/examples/ale/train_ppo_ale.py
+++ b/examples/ale/train_ppo_ale.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import argparse
 import os
 

--- a/examples/gym/train_a3c_gym.py
+++ b/examples/gym/train_a3c_gym.py
@@ -26,7 +26,7 @@ import chainer
 from chainer import functions as F
 from chainer import links as L
 import gym
-gym.undo_logger_setup()
+gym.undo_logger_setup()  # NOQA
 import gym.wrappers
 import numpy as np
 

--- a/examples/gym/train_a3c_gym.py
+++ b/examples/gym/train_a3c_gym.py
@@ -15,7 +15,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import argparse
 import os
 

--- a/examples/gym/train_a3c_gym.py
+++ b/examples/gym/train_a3c_gym.py
@@ -20,7 +20,7 @@ import argparse
 import os
 
 # This prevents numpy from using multiple threads
-os.environ['OMP_NUM_THREADS'] = '1'
+os.environ['OMP_NUM_THREADS'] = '1'  # NOQA
 
 import chainer
 from chainer import functions as F

--- a/examples/gym/train_acer_gym.py
+++ b/examples/gym/train_acer_gym.py
@@ -9,7 +9,7 @@ import argparse
 import os
 
 # This prevents numpy from using multiple threads
-os.environ['OMP_NUM_THREADS'] = '1'
+os.environ['OMP_NUM_THREADS'] = '1'  # NOQA
 
 import chainer
 from chainer import functions as F

--- a/examples/gym/train_acer_gym.py
+++ b/examples/gym/train_acer_gym.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import argparse
 import os
 

--- a/examples/gym/train_categorical_dqn_gym.py
+++ b/examples/gym/train_categorical_dqn_gym.py
@@ -19,7 +19,7 @@ import sys
 
 from chainer import optimizers
 import gym
-gym.undo_logger_setup()
+gym.undo_logger_setup()  # NOQA
 import gym.wrappers
 import numpy as np
 

--- a/examples/gym/train_categorical_dqn_gym.py
+++ b/examples/gym/train_categorical_dqn_gym.py
@@ -12,7 +12,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import argparse
 import sys

--- a/examples/gym/train_ddpg_gym.py
+++ b/examples/gym/train_ddpg_gym.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import argparse
 import sys
 

--- a/examples/gym/train_ddpg_gym.py
+++ b/examples/gym/train_ddpg_gym.py
@@ -10,7 +10,7 @@ import sys
 import chainer
 from chainer import optimizers
 import gym
-gym.undo_logger_setup()
+gym.undo_logger_setup()  # NOQA
 from gym import spaces
 import gym.wrappers
 import numpy as np

--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -24,7 +24,7 @@ import sys
 
 from chainer import optimizers
 import gym
-gym.undo_logger_setup()
+gym.undo_logger_setup()  # NOQA
 from gym import spaces
 import gym.wrappers
 import numpy as np

--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -16,7 +16,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import argparse
 import os

--- a/examples/gym/train_pcl_gym.py
+++ b/examples/gym/train_pcl_gym.py
@@ -15,7 +15,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import argparse
 import os
 

--- a/examples/gym/train_pcl_gym.py
+++ b/examples/gym/train_pcl_gym.py
@@ -20,7 +20,7 @@ import argparse
 import os
 
 # This prevents numpy from using multiple threads
-os.environ['OMP_NUM_THREADS'] = '1'
+os.environ['OMP_NUM_THREADS'] = '1'  # NOQA
 
 import chainer
 import gym

--- a/examples/gym/train_pcl_gym.py
+++ b/examples/gym/train_pcl_gym.py
@@ -24,7 +24,7 @@ os.environ['OMP_NUM_THREADS'] = '1'
 
 import chainer
 import gym
-gym.undo_logger_setup()
+gym.undo_logger_setup()  # NOQA
 import gym.wrappers
 import numpy as np
 

--- a/examples/gym/train_ppo_gym.py
+++ b/examples/gym/train_ppo_gym.py
@@ -18,7 +18,7 @@ import argparse
 import chainer
 from chainer import functions as F
 import gym
-gym.undo_logger_setup()
+gym.undo_logger_setup()  # NOQA
 import gym.wrappers
 import numpy as np
 

--- a/examples/gym/train_ppo_gym.py
+++ b/examples/gym/train_ppo_gym.py
@@ -12,7 +12,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import argparse
 
 import chainer

--- a/examples/gym/train_reinforce_gym.py
+++ b/examples/gym/train_reinforce_gym.py
@@ -15,7 +15,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import argparse
 import os
 

--- a/examples/gym/train_reinforce_gym.py
+++ b/examples/gym/train_reinforce_gym.py
@@ -21,7 +21,7 @@ import os
 
 import chainer
 import gym
-gym.undo_logger_setup()
+gym.undo_logger_setup()  # NOQA
 import gym.wrappers
 import numpy as np
 

--- a/examples/gym/train_trpo_gym.py
+++ b/examples/gym/train_trpo_gym.py
@@ -17,7 +17,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import argparse
 import logging

--- a/examples/gym/train_trpo_gym.py
+++ b/examples/gym/train_trpo_gym.py
@@ -26,7 +26,7 @@ import os
 import chainer
 from chainer import functions as F
 import gym
-gym.undo_logger_setup()
+gym.undo_logger_setup()  # NOQA
 import gym.wrappers
 import numpy as np
 

--- a/tests/agents_tests/basetest_agents.py
+++ b/tests/agents_tests/basetest_agents.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import os
 import tempfile
 import unittest

--- a/tests/agents_tests/basetest_ddpg.py
+++ b/tests/agents_tests/basetest_ddpg.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from chainer import optimizers
 import numpy as np

--- a/tests/agents_tests/basetest_dqn_like.py
+++ b/tests/agents_tests/basetest_dqn_like.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from chainer import optimizers
 import numpy as np

--- a/tests/agents_tests/basetest_pgt.py
+++ b/tests/agents_tests/basetest_pgt.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer
 from chainer import functions as F

--- a/tests/agents_tests/basetest_training.py
+++ b/tests/agents_tests/basetest_training.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import logging
 import os

--- a/tests/agents_tests/test_a3c.py
+++ b/tests/agents_tests/test_a3c.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import logging
 import os

--- a/tests/agents_tests/test_acer.py
+++ b/tests/agents_tests/test_acer.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import copy
 import logging

--- a/tests/agents_tests/test_agents.py
+++ b/tests/agents_tests/test_agents.py
@@ -8,7 +8,7 @@ standard_library.install_aliases()  # NOQA
 from chainer import optimizers
 from chainer import testing
 import gym
-gym.undo_logger_setup()
+gym.undo_logger_setup()  # NOQA
 
 import basetest_agents as base
 from chainerrl import agents

--- a/tests/agents_tests/test_agents.py
+++ b/tests/agents_tests/test_agents.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from chainer import optimizers
 from chainer import testing

--- a/tests/agents_tests/test_al.py
+++ b/tests/agents_tests/test_al.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 from builtins import *  # NOQA
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import basetest_dqn_like as base
 from chainerrl.agents.al import AL

--- a/tests/agents_tests/test_categorical_dqn.py
+++ b/tests/agents_tests/test_categorical_dqn.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 from builtins import *  # NOQA
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import unittest
 
 import chainer

--- a/tests/agents_tests/test_ddpg.py
+++ b/tests/agents_tests/test_ddpg.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import basetest_ddpg as base
 from chainerrl.agents.ddpg import DDPG

--- a/tests/agents_tests/test_double_dqn.py
+++ b/tests/agents_tests/test_double_dqn.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from chainerrl.agents.double_dqn import DoubleDQN
 

--- a/tests/agents_tests/test_double_pal.py
+++ b/tests/agents_tests/test_double_pal.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 from builtins import *  # NOQA
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from chainerrl.agents.double_pal import DoublePAL
 

--- a/tests/agents_tests/test_dpp.py
+++ b/tests/agents_tests/test_dpp.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 from chainer import testing
 

--- a/tests/agents_tests/test_dqn.py
+++ b/tests/agents_tests/test_dqn.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 from builtins import *  # NOQA
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import basetest_dqn_like as base
 import chainerrl

--- a/tests/agents_tests/test_nsq.py
+++ b/tests/agents_tests/test_nsq.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import logging
 import os

--- a/tests/agents_tests/test_pal.py
+++ b/tests/agents_tests/test_pal.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import basetest_dqn_like as base
 from chainerrl.agents.pal import PAL

--- a/tests/agents_tests/test_pcl.py
+++ b/tests/agents_tests/test_pcl.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import logging
 import os

--- a/tests/agents_tests/test_pgt.py
+++ b/tests/agents_tests/test_pgt.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import basetest_pgt as base
 from chainerrl.agents.pgt import PGT

--- a/tests/agents_tests/test_ppo.py
+++ b/tests/agents_tests/test_ppo.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import os
 import tempfile

--- a/tests/agents_tests/test_reinforce.py
+++ b/tests/agents_tests/test_reinforce.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import logging
 import tempfile

--- a/tests/agents_tests/test_residual_dqn.py
+++ b/tests/agents_tests/test_residual_dqn.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import basetest_dqn_like as base
 from chainerrl.agents.residual_dqn import ResidualDQN

--- a/tests/agents_tests/test_sarsa.py
+++ b/tests/agents_tests/test_sarsa.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 from builtins import *  # NOQA
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import basetest_dqn_like as base
 from chainerrl.agents import SARSA

--- a/tests/agents_tests/test_trpo.py
+++ b/tests/agents_tests/test_trpo.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import os
 import tempfile

--- a/tests/experiments_tests/test_evaluator.py
+++ b/tests/experiments_tests/test_evaluator.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import tempfile
 import unittest

--- a/tests/experiments_tests/test_hooks.py
+++ b/tests/experiments_tests/test_hooks.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import unittest
 
 import numpy as np

--- a/tests/experiments_tests/test_prepare_output_dir.py
+++ b/tests/experiments_tests/test_prepare_output_dir.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import contextlib
 import json
 import os

--- a/tests/experiments_tests/test_train_agent.py
+++ b/tests/experiments_tests/test_train_agent.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import tempfile
 import unittest
 

--- a/tests/explorers_tests/test_additive_gaussian.py
+++ b/tests/explorers_tests/test_additive_gaussian.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import unittest
 
 import numpy as np

--- a/tests/explorers_tests/test_additive_ou.py
+++ b/tests/explorers_tests/test_additive_ou.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import unittest
 
 from chainer import testing

--- a/tests/explorers_tests/test_boltzmann.py
+++ b/tests/explorers_tests/test_boltzmann.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import unittest
 

--- a/tests/explorers_tests/test_epsilon_greedy.py
+++ b/tests/explorers_tests/test_epsilon_greedy.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import logging
 import unittest

--- a/tests/functions_tests/test_lower_triangular_matrix.py
+++ b/tests/functions_tests/test_lower_triangular_matrix.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import unittest
 
 import numpy

--- a/tests/functions_tests/test_sum_arrays.py
+++ b/tests/functions_tests/test_sum_arrays.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import unittest
 
 import numpy

--- a/tests/functions_tests/test_weighted_sum_arrays.py
+++ b/tests/functions_tests/test_weighted_sum_arrays.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import unittest
 
 import numpy

--- a/tests/links_tests/test_mlp_bn.py
+++ b/tests/links_tests/test_mlp_bn.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import unittest
 

--- a/tests/links_tests/test_sequence.py
+++ b/tests/links_tests/test_sequence.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import unittest
 

--- a/tests/misc_tests/test_async.py
+++ b/tests/misc_tests/test_async.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import multiprocessing as mp
 import os

--- a/tests/misc_tests/test_collections.py
+++ b/tests/misc_tests/test_collections.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import collections
 import unittest

--- a/tests/misc_tests/test_conjugate_gradient.py
+++ b/tests/misc_tests/test_conjugate_gradient.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import unittest
 
 import chainer

--- a/tests/misc_tests/test_copy_param.py
+++ b/tests/misc_tests/test_copy_param.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import unittest
 
 import chainer

--- a/tests/misc_tests/test_draw_computational_graph.py
+++ b/tests/misc_tests/test_draw_computational_graph.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import os
 import tempfile

--- a/tests/misc_tests/test_is_return_code_zero.py
+++ b/tests/misc_tests/test_is_return_code_zero.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import unittest
 

--- a/tests/misc_tests/test_prioritized.py
+++ b/tests/misc_tests/test_prioritized.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import unittest
 
 import numpy as np

--- a/tests/misc_tests/test_random.py
+++ b/tests/misc_tests/test_random.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import timeit
 import unittest

--- a/tests/misc_tests/test_random_seed.py
+++ b/tests/misc_tests/test_random_seed.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 from builtins import *  # NOQA
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import random
 import unittest

--- a/tests/policies_tests/test_deterministic_policy.py
+++ b/tests/policies_tests/test_deterministic_policy.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import unittest
 

--- a/tests/q_functions_tests/basetest_state_action_q_function.py
+++ b/tests/q_functions_tests/basetest_state_action_q_function.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import unittest
 

--- a/tests/q_functions_tests/test_state_action_q_function.py
+++ b/tests/q_functions_tests/test_state_action_q_function.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import chainer.functions as F
 from chainer import testing

--- a/tests/test_action_value.py
+++ b/tests/test_action_value.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import unittest
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import os
 import tempfile

--- a/tests/test_ale.py
+++ b/tests/test_ale.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import random
 import sys

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 
 import unittest
 

--- a/tests/test_replay_buffer.py
+++ b/tests/test_replay_buffer.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 import os
 import tempfile
 import unittest

--- a/tests/test_replay_buffer_old.py
+++ b/tests/test_replay_buffer_old.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
-standard_library.install_aliases()
+standard_library.install_aliases()  # NOQA
 from collections import deque
 import os
 import tempfile

--- a/tests/test_replay_buffer_old.py
+++ b/tests/test_replay_buffer_old.py
@@ -83,11 +83,6 @@ class ReplayBufferV0_2(object):
                           is_state_terminal=is_state_terminal)
         self.memory.append(experience)
 
-    def sample(self, n):
-        """Sample n unique samples from this replay buffer"""
-        assert len(self.memory) >= n
-        return random.sample(self.memory, n)
-
     def __len__(self):
         return len(self.memory)
 
@@ -130,20 +125,6 @@ class EpisodicReplayBufferV0_2(object):
         self.current_episode.append(experience)
         if is_state_terminal:
             self.stop_current_episode()
-
-    def sample(self, n):
-        """Sample n unique samples from this replay buffer"""
-        assert len(self.memory) >= n
-        return random.sample(self.memory, n)
-
-    def sample_episodes(self, n_episodes, max_len=None):
-        """Sample n unique samples from this replay buffer"""
-        assert len(self.episodic_memory) >= n_episodes
-        episodes = random.sample(self.episodic_memory, n_episodes)
-        if max_len is not None:
-            return [random_subseq(ep, max_len) for ep in episodes]
-        else:
-            return episodes
 
     def __len__(self):
         return len(self.episodic_memory)


### PR DESCRIPTION
Close #263.

Note: `# noqa: E402` works, but with any error number (like `# noqa: E234`) it seems to disable E402.