### PR TITLE
Update Policy class to inherit ABCMeta 

### DIFF
--- a/chainerrl/policy.py
+++ b/chainerrl/policy.py
@@ -6,12 +6,16 @@ from builtins import *  # NOQA
 from future import standard_library
 standard_library.install_aliases()  # NOQA
 
+from abc import ABCMeta
 from abc import abstractmethod
+
+from future.utils import with_metaclass
+
 from logging import getLogger
 logger = getLogger(__name__)
 
 
-class Policy(object):
+class Policy(with_metaclass(ABCMeta, object)):
     """Abstract policy."""
 
     @abstractmethod


### PR DESCRIPTION
Updated Policy class to inherit ABCMeta. 
It is because Policy class had abstract method, but did not inherit ABCMeta class.
[Python docs](https://docs.python.org/3/library/abc.html) says that decorator `@abstractmethod` requires that the class’s metaclass is ABCMeta or is derived from it.