### PR TITLE
Remove GaussianPolicy and obsolete policies

### DIFF
--- a/chainerrl/__init__.py
+++ b/chainerrl/__init__.py
@@ -31,10 +31,6 @@ policy.FCLSTMDeterministicPolicy = policies.FCLSTMDeterministicPolicy
 policy.FCLSTMDeterministicPolicy = policies.FCLSTMDeterministicPolicy
 policy.GaussianPolicy = policies.GaussianPolicy
 policy.FCGaussianPolicy = policies.FCGaussianPolicy
-policy.LinearGaussianPolicyWithDiagonalCovariance = \
-    policies.LinearGaussianPolicyWithDiagonalCovariance
-policy.LinearGaussianPolicyWithSphericalCovariance = \
-    policies.LinearGaussianPolicyWithSphericalCovariance
 policy.MellowmaxPolicy = policies.MellowmaxPolicy
 
 q_function.DuelingDQN = q_functions.DuelingDQN

--- a/chainerrl/__init__.py
+++ b/chainerrl/__init__.py
@@ -29,7 +29,6 @@ policy.FCDeterministicPolicy = policies.FCDeterministicPolicy
 policy.FCBNDeterministicPolicy = policies.FCBNDeterministicPolicy
 policy.FCLSTMDeterministicPolicy = policies.FCLSTMDeterministicPolicy
 policy.FCLSTMDeterministicPolicy = policies.FCLSTMDeterministicPolicy
-policy.GaussianPolicy = policies.GaussianPolicy
 policy.FCGaussianPolicy = policies.FCGaussianPolicy
 policy.MellowmaxPolicy = policies.MellowmaxPolicy
 

--- a/examples/gym/train_a3c_gym.py
+++ b/examples/gym/train_a3c_gym.py
@@ -76,8 +76,7 @@ class A3CLSTMGaussian(chainer.ChainList, a3c.A3CModel, RecurrentChainMixin):
         self.v_head = L.Linear(obs_size, hidden_size)
         self.pi_lstm = L.LSTM(hidden_size, lstm_size)
         self.v_lstm = L.LSTM(hidden_size, lstm_size)
-        self.pi = policies.LinearGaussianPolicyWithDiagonalCovariance(
-            lstm_size, action_size)
+        self.pi = policies.FCGaussianPolicy(lstm_size, action_size)
         self.v = v_function.FCVFunction(lstm_size)
         super().__init__(self.pi_head, self.v_head,
                          self.pi_lstm, self.v_lstm, self.pi, self.v)


### PR DESCRIPTION
Resolves #276 and #281 

Since `LinearGaussianPolicyWithDiagonalCovariance` hard-codes squashing actions by tanh, replacing it with `FCGaussianPolicy` will change the behavior. I confirmed that `train_a3c_gym.py` can solve `InvertedPendulum-v1` as before by running `python train_a3c_gym.py 4 --env InvertedPendulum-v1 --arch LSTMGaussian --t-max 50`.