### PR TITLE
Make random access queue sampling code cleaner

### DIFF
--- a/chainerrl/misc/collections.py
+++ b/chainerrl/misc/collections.py
@@ -107,6 +107,4 @@ class RandomAccessQueue(object):
         return self._queue_front.pop()
 
     def sample(self, k):
-        nf = len(self._queue_front)
-        return [self._queue_front[i] if i < nf else self._queue_back[i - nf]
-                for i in sample_n_k(len(self), k)]
+        return [self[i] for i in sample_n_k(len(self), k)]


### PR DESCRIPTION
We have previously overridden the __getitem__ operator. However, the sampling method doesn't make use of this override, and instead replicates much of the code in that method. This commit does change the semantics of what occurs in practice. However, due to the uniformity of sampling, in expectation it does the same thing. In a nutshell, both the previous code as well as this commit implement uniform sampling. However, the indexes that are chosen are different between the previous code and this one.