### PR TITLE
Use RandomizeAction wrapper instead of Explorer in evaluation

### DIFF
--- a/chainerrl/experiments/train_agent.py
+++ b/chainerrl/experiments/train_agent.py
@@ -96,7 +96,6 @@ def train_agent_with_evaluation(agent,
                                 outdir,
                                 max_episode_len=None,
                                 step_offset=0,
-                                eval_explorer=None,
                                 eval_max_episode_len=None,
                                 eval_env=None,
                                 successful_score=None,
@@ -115,7 +114,6 @@ def train_agent_with_evaluation(agent,
         outdir (str): Path to the directory to output things.
         max_episode_len (int): Maximum episode length.
         step_offset (int): Time step from which training starts.
-        eval_explorer: Explorer used for evaluation.
         eval_max_episode_len (int or None): Maximum episode length of
             evaluation runs. If set to None, max_episode_len is used instead.
         eval_env: Environment used for evaluation.
@@ -144,7 +142,6 @@ def train_agent_with_evaluation(agent,
                           n_runs=eval_n_runs,
                           eval_interval=eval_interval, outdir=outdir,
                           max_episode_len=eval_max_episode_len,
-                          explorer=eval_explorer,
                           env=eval_env,
                           step_offset=step_offset,
                           save_best_so_far_agent=save_best_so_far_agent,

--- a/chainerrl/experiments/train_agent_async.py
+++ b/chainerrl/experiments/train_agent_async.py
@@ -131,7 +131,6 @@ def train_agent_async(outdir, processes, make_env,
                       max_episode_len=None,
                       step_offset=0,
                       successful_score=None,
-                      eval_explorer=None,
                       agent=None,
                       make_agent=None,
                       global_step_hooks=[],
@@ -155,7 +154,6 @@ def train_agent_async(outdir, processes, make_env,
         step_offset (int): Time step from which training starts.
         successful_score (float): Finish training if the mean score is greater
             or equal to this value if not None
-        eval_explorer: Explorer used for evaluation.
         agent (Agent): Agent to train.
         make_agent (callable): (process_idx) -> Agent
         global_step_hooks (list): List of callable objects that accepts
@@ -194,7 +192,6 @@ def train_agent_async(outdir, processes, make_env,
             eval_interval=eval_interval, outdir=outdir,
             max_episode_len=max_episode_len,
             step_offset=step_offset,
-            explorer=eval_explorer,
             save_best_so_far_agent=save_best_so_far_agent,
             logger=logger,
         )

--- a/chainerrl/wrappers/__init__.py
+++ b/chainerrl/wrappers/__init__.py
@@ -1,2 +1,4 @@
 from chainerrl.wrappers.cast_observation import CastObservation  # NOQA
 from chainerrl.wrappers.cast_observation import CastObservationToFloat32  # NOQA
+
+from chainerrl.wrappers.randomize_action import RandomizeAction  # NOQA

--- a/chainerrl/wrappers/randomize_action.py
+++ b/chainerrl/wrappers/randomize_action.py
@@ -13,7 +13,11 @@ import numpy as np
 class RandomizeAction(gym.ActionWrapper):
     """Apply a random action instead of the one sent by the agent.
 
-    This wrapper can be used to make a stochastic env.
+    This wrapper can be used to make a stochastic env. The common use is
+    for evaluation in Atari environments, where actions are replaced with
+    random ones with a low probability.
+
+    Only gym.spaces.Discrete is supported as an action space.
 
     For exploration during training, use explorers like
     chainerrl.explorers.ConstantEpsilonGreedy instead of this wrapper.

--- a/chainerrl/wrappers/randomize_action.py
+++ b/chainerrl/wrappers/randomize_action.py
@@ -31,7 +31,8 @@ class RandomizeAction(gym.ActionWrapper):
     def __init__(self, env, random_fraction):
         super().__init__(env)
         assert 0 <= random_fraction <= 1
-        assert isinstance(env.action_space, gym.spaces.Discrete)
+        assert isinstance(env.action_space, gym.spaces.Discrete),\
+            'RandomizeAction supports only gym.spaces.Discrete as an action space'  # NOQA
         self._random_fraction = random_fraction
         self._np_random = np.random.RandomState()
 

--- a/chainerrl/wrappers/randomize_action.py
+++ b/chainerrl/wrappers/randomize_action.py
@@ -1,0 +1,43 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()  # NOQA
+
+import gym
+import numpy as np
+
+
+class RandomizeAction(gym.ActionWrapper):
+    """Apply a random action instead of the one sent by the agent.
+
+    This wrapper can be used to make a stochastic env.
+
+    For exploration during training, use explorers like
+    chainerrl.explorers.ConstantEpsilonGreedy instead of this wrapper.
+
+    Args:
+        env (gym.Env): Env to wrap.
+        random_fraction (float): Fraction of actions that will be replaced
+            with a random action. It must be in [0, 1].
+    """
+
+    def __init__(self, env, random_fraction):
+        super().__init__(env)
+        assert 0 <= random_fraction <= 1
+        assert isinstance(env.action_space, gym.spaces.Discrete)
+        self.random_fraction = random_fraction
+        self.original_action = None
+        self.np_random = np.random.RandomState()
+
+    def _action(self, action):
+        self.original_action = original_action
+        if self.np_random.rand() < self.random_fraction:
+            return self.np_random.randint(self.env.action_space.n)
+        else:
+            return self.original_action
+
+    def _seed(self, seed):
+        self.np_random.seed(seed)

--- a/chainerrl/wrappers/randomize_action.py
+++ b/chainerrl/wrappers/randomize_action.py
@@ -28,17 +28,15 @@ class RandomizeAction(gym.ActionWrapper):
         super().__init__(env)
         assert 0 <= random_fraction <= 1
         assert isinstance(env.action_space, gym.spaces.Discrete)
-        self.random_fraction = random_fraction
-        self.original_action = None
-        self.np_random = np.random.RandomState()
+        self._random_fraction = random_fraction
+        self._np_random = np.random.RandomState()
 
     def _action(self, action):
-        self.original_action = action
-        if self.np_random.rand() < self.random_fraction:
-            return self.np_random.randint(self.env.action_space.n)
+        if self._np_random.rand() < self._random_fraction:
+            return self._np_random.randint(self.env.action_space.n)
         else:
-            return self.original_action
+            return action
 
     def seed(self, seed):
         super().seed(seed)
-        self.np_random.seed(seed)
+        self._np_random.seed(seed)

--- a/chainerrl/wrappers/randomize_action.py
+++ b/chainerrl/wrappers/randomize_action.py
@@ -33,11 +33,12 @@ class RandomizeAction(gym.ActionWrapper):
         self.np_random = np.random.RandomState()
 
     def _action(self, action):
-        self.original_action = original_action
+        self.original_action = action
         if self.np_random.rand() < self.random_fraction:
             return self.np_random.randint(self.env.action_space.n)
         else:
             return self.original_action
 
-    def _seed(self, seed):
+    def seed(self, seed):
+        super().seed(seed)
         self.np_random.seed(seed)

--- a/examples/ale/train_categorical_dqn_ale.py
+++ b/examples/ale/train_categorical_dqn_ale.py
@@ -79,6 +79,9 @@ def main():
             episode_life=not test,
             clip_rewards=not test)
         env.seed(int(env_seed))
+        if test:
+            # Randomize actions like epsilon-greedy in evaluation as well
+            env = chainerrl.wrappers.RandomizeAction(env, args.eval_epsilon)
         if args.monitor:
             env = gym.wrappers.Monitor(
                 env, args.outdir,
@@ -143,13 +146,10 @@ def main():
             args.eval_n_runs, eval_stats['mean'], eval_stats['median'],
             eval_stats['stdev']))
     else:
-        # In testing DQN, randomly select 5% of actions
-        eval_explorer = explorers.ConstantEpsilonGreedy(
-            args.eval_epsilon, lambda: np.random.randint(n_actions))
         experiments.train_agent_with_evaluation(
             agent=agent, env=env, steps=args.steps,
             eval_n_runs=args.eval_n_runs, eval_interval=args.eval_interval,
-            outdir=args.outdir, eval_explorer=eval_explorer,
+            outdir=args.outdir,
             save_best_so_far_agent=False,
             max_episode_len=args.max_episode_len,
             eval_env=eval_env,

--- a/examples/ale/train_dqn_ale.py
+++ b/examples/ale/train_dqn_ale.py
@@ -143,6 +143,9 @@ def main():
             episode_life=not test,
             clip_rewards=not test)
         env.seed(int(env_seed))
+        if test:
+            # Randomize actions like epsilon-greedy in evaluation as well
+            env = chainerrl.wrappers.RandomizeAction(env, args.eval_epsilon)
         if args.monitor:
             env = gym.wrappers.Monitor(
                 env, args.outdir,
@@ -212,13 +215,10 @@ def main():
             args.eval_n_runs, eval_stats['mean'], eval_stats['median'],
             eval_stats['stdev']))
     else:
-        # In testing DQN, randomly select 5% of actions
-        eval_explorer = explorers.ConstantEpsilonGreedy(
-            args.eval_epsilon, lambda: np.random.randint(n_actions))
         experiments.train_agent_with_evaluation(
             agent=agent, env=env, steps=args.steps,
             eval_n_runs=args.eval_n_runs, eval_interval=args.eval_interval,
-            outdir=args.outdir, eval_explorer=eval_explorer,
+            outdir=args.outdir,
             save_best_so_far_agent=False,
             max_episode_len=args.max_episode_len,
             eval_env=eval_env,

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -19,6 +19,7 @@ from gym import spaces
 import gym.wrappers
 import numpy as np
 
+import chainerrl
 from chainerrl.action_value import DiscreteActionValue
 from chainerrl.agents import nsq
 from chainerrl import experiments

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -87,6 +87,9 @@ def main():
             episode_life=not test,
             clip_rewards=not test)
         env.seed(int(env_seed))
+        if test:
+            # Randomize actions like epsilon-greedy in evaluation as well
+            env = chainerrl.wrappers.RandomizeAction(env, 0.05)
         if args.monitor:
             env = gym.wrappers.Monitor(
                 env, args.outdir,
@@ -141,8 +144,6 @@ def main():
             args.eval_n_runs, eval_stats['mean'], eval_stats['median'],
             eval_stats['stdev']))
     else:
-        explorer = explorers.ConstantEpsilonGreedy(0.05, action_space.sample)
-
         # Linearly decay the learning rate to zero
         def lr_setter(env, agent, value):
             agent.optimizer.lr = value
@@ -159,7 +160,6 @@ def main():
             steps=args.steps,
             eval_n_runs=args.eval_n_runs,
             eval_interval=args.eval_interval,
-            eval_explorer=explorer,
             max_episode_len=args.max_episode_len,
             global_step_hooks=[lr_decay_hook],
             save_best_so_far_agent=False,

--- a/tests/experiments_tests/test_evaluator.py
+++ b/tests/experiments_tests/test_evaluator.py
@@ -41,7 +41,6 @@ class TestEvaluator(unittest.TestCase):
             eval_interval=3,
             outdir=outdir,
             max_episode_len=None,
-            explorer=None,
             step_offset=0,
             save_best_so_far_agent=self.save_best_so_far_agent,
         )
@@ -105,7 +104,6 @@ class TestAsyncEvaluator(unittest.TestCase):
             eval_interval=3,
             outdir=outdir,
             max_episode_len=None,
-            explorer=None,
             step_offset=0,
             save_best_so_far_agent=self.save_best_so_far_agent,
         )

--- a/tests/wrappers_tests/test_randomize_action.py
+++ b/tests/wrappers_tests/test_randomize_action.py
@@ -1,0 +1,88 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()  # NOQA
+
+import unittest
+
+from chainer import testing
+from chainer.testing import condition
+import gym
+import gym.spaces
+
+import chainerrl
+
+
+class ActionRecordingEnv(gym.Env):
+
+    observation_space = gym.spaces.Box(low=-1, high=1, shape=(1,))
+    action_space = gym.spaces.Discrete(3)
+
+    def __init__(self):
+        self.past_actions = []
+
+    def reset(self):
+        return self.observation_space.sample()
+
+    def step(self, action):
+        self.past_actions.append(action)
+        return self.observation_space.sample(), 0, False, {}
+
+
+@testing.parameterize(*testing.product({
+    'random_fraction': [0, 0.3, 0.6, 1],
+}))
+class TestRandomizeAction(unittest.TestCase):
+
+    @condition.retry(3)
+    def test_action_ratio(self):
+        random_fraction = self.random_fraction
+        env = ActionRecordingEnv()
+        env = chainerrl.wrappers.RandomizeAction(
+            env, random_fraction=random_fraction)
+        env.reset()
+        n = 1000
+        delta = 0.05
+        for _ in range(n):
+            # Always send action 0
+            env.step(0)
+        # Ratio of selected actions should be:
+        #   0: (1 - random_fraction) + random_fraction/3
+        #   1: random_fraction/3
+        #   2: random_fraction/3
+        self.assertAlmostEqual(
+            env.env.past_actions.count(0) / n,
+            (1 - random_fraction) + random_fraction / 3, delta=delta)
+        self.assertAlmostEqual(
+            env.env.past_actions.count(1) / n,
+            random_fraction / 3, delta=delta)
+        self.assertAlmostEqual(
+            env.env.past_actions.count(2) / n,
+            random_fraction / 3, delta=delta)
+
+    @condition.retry(3)
+    def test_seed(self):
+
+        def get_actions(seed):
+            random_fraction = self.random_fraction
+            env = ActionRecordingEnv()
+            env = chainerrl.wrappers.RandomizeAction(
+                env, random_fraction=random_fraction)
+            env.seed(seed)
+            for _ in range(1000):
+                # Always send action 0
+                env.step(0)
+            return env.env.past_actions
+
+        a_seed0 = get_actions(0)
+        a_seed1 = get_actions(1)
+        b_seed0 = get_actions(0)
+        b_seed1 = get_actions(1)
+
+        self.assertEqual(a_seed0, b_seed0)
+        self.assertEqual(a_seed1, b_seed1)
+        if self.random_fraction > 0:
+            self.assertNotEqual(a_seed0, a_seed1)


### PR DESCRIPTION
We currently use `Explorer` to inject randomness to action selection in evaluation, which is common in Atari benchmarks. This use is actually irrelevant to exploration in training, so is a misnomer in my opinion.

I think we better use an env wrapper for this purpose, so that the training and evaluation code can be simpler. This is also important in #326 , where I need to implement another set of code for training and evaluation.