### PR TITLE
Stop caching the result of numpy.concatenate in LazyFrames

### DIFF
--- a/examples/ale/atari_wrappers.py
+++ b/examples/ale/atari_wrappers.py
@@ -230,25 +230,12 @@ class LazyFrames(object):
     def __init__(self, frames, stack_axis=2):
         self.stack_axis = stack_axis
         self._frames = frames
-        self._out = None
-
-    def _force(self):
-        if self._out is None:
-            self._out = np.concatenate(self._frames, axis=self.stack_axis)
-            self._frames = None
-        return self._out
 
     def __array__(self, dtype=None):
-        out = self._force()
+        out = np.concatenate(self._frames, axis=self.stack_axis)
         if dtype is not None:
             out = out.astype(dtype)
         return out
-
-    def __len__(self):
-        return len(self._force())
-
-    def __getitem__(self, i):
-        return self._force()[i]
 
 
 def make_atari(env_id):


### PR DESCRIPTION
This change saves a lot of memory. See https://github.com/openai/baselines/issues/295.

- [x] check if it does not affect scores