### PR TITLE
Make clip_eps positive

### DIFF
--- a/examples/ale/train_ppo_ale.py
+++ b/examples/ale/train_ppo_ale.py
@@ -151,7 +151,7 @@ def main():
 
         # Linearly decay the clipping parameter to zero
         def clip_eps_setter(env, agent, value):
-            agent.clip_eps = value
+            agent.clip_eps = max(value, 1e-8)
 
         clip_eps_decay_hook = experiments.LinearInterpolationHook(
             args.steps, 0.1, 0, clip_eps_setter)

--- a/examples/gym/train_ppo_gym.py
+++ b/examples/gym/train_ppo_gym.py
@@ -199,7 +199,7 @@ def main():
 
         # Linearly decay the clipping parameter to zero
         def clip_eps_setter(env, agent, value):
-            agent.clip_eps = value
+            agent.clip_eps = max(value, 1e-8)
 
         clip_eps_decay_hook = experiments.LinearInterpolationHook(
             args.steps, 0.2, 0, clip_eps_setter)


### PR DESCRIPTION
because clip_eps=0 can cause PPO to raise an error. F.clip asserts x_min < x_max.

Current PPO does not update the model at `stop_episode_and_train`, so it has not raised any errors so far. However, I think it *should* update the model at `stop_episode_and_train` when the amount of transitions reaches `update_interval` by that call of `stop_episode_and_train`.

#326 will change the behavior of PPO so that it will update the model in such cases, thus depends on this PR.