### PR TITLE
Count updates of DQN

### DIFF
--- a/chainerrl/agents/dqn.py
+++ b/chainerrl/agents/dqn.py
@@ -177,7 +177,6 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
         self.average_q_decay = average_q_decay
         self.average_loss = 0
         self.average_loss_decay = average_loss_decay
-        self.n_updates = 0
 
     def sync_target_network(self):
         """Synchronize target network with current network."""
@@ -230,7 +229,6 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
         # Update stats
         self.average_loss *= self.average_loss_decay
         self.average_loss += (1 - self.average_loss_decay) * float(loss.array)
-        self.n_updates += 1
 
         self.model.cleargrads()
         loss.backward()
@@ -440,5 +438,5 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
         return [
             ('average_q', self.average_q),
             ('average_loss', self.average_loss),
-            ('n_updates', self.n_updates),
+            ('n_updates', self.optimizer.t),
         ]

--- a/chainerrl/agents/dqn.py
+++ b/chainerrl/agents/dqn.py
@@ -177,6 +177,7 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
         self.average_q_decay = average_q_decay
         self.average_loss = 0
         self.average_loss_decay = average_loss_decay
+        self.n_updates = 0
 
     def sync_target_network(self):
         """Synchronize target network with current network."""
@@ -229,6 +230,7 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
         # Update stats
         self.average_loss *= self.average_loss_decay
         self.average_loss += (1 - self.average_loss_decay) * float(loss.array)
+        self.n_updates += 1
 
         self.model.cleargrads()
         loss.backward()
@@ -438,4 +440,5 @@ class DQN(agent.AttributeSavingMixin, agent.Agent):
         return [
             ('average_q', self.average_q),
             ('average_loss', self.average_loss),
+            ('n_updates', self.n_updates),
         ]


### PR DESCRIPTION
This PR will add `n_updates` to the statistics of DQN. It is helpful for debugging.

I confirmed that
```
python examples/gym/train_dqn_gym.py --gpu -1 --replay-start-size 1000 --update-interval 1 --steps 2000
```
gets `('n_updates', 1000)`
```
INFO:chainerrl.experiments.train_agent:outdir:results/20181024T204226.214715 step:2000 episode:9 R:-1.3913073996433227
INFO:chainerrl.experiments.train_agent:statistics:[('average_q', 0.3017159130785429), ('average_loss', 0.002146864709680402), ('n_updates', 1000)]
```
, and
```
python examples/gym/train_dqn_gym.py --gpu -1 --replay-start-size 1000 --update-interval 2 --steps 2000
```
gets `('n_updates', 500)`
```
INFO:chainerrl.experiments.train_agent:outdir:results/20181024T204321.815223 step:2000 episode:9 R:-1.1019894359275235
INFO:chainerrl.experiments.train_agent:statistics:[('average_q', 0.25655420187569583), ('average_loss', 0.002052869248714256), ('n_updates', 500)]
```
.
