### PR TITLE
Render wrapper

### DIFF
--- a/chainerrl/wrappers/__init__.py
+++ b/chainerrl/wrappers/__init__.py
@@ -3,4 +3,6 @@ from chainerrl.wrappers.cast_observation import CastObservationToFloat32  # NOQA
 
 from chainerrl.wrappers.randomize_action import RandomizeAction  # NOQA
 
+from chainerrl.wrappers.render import Render  # NOQA
+
 from chainerrl.wrappers.scale_reward import ScaleReward  # NOQA

--- a/chainerrl/wrappers/render.py
+++ b/chainerrl/wrappers/render.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()  # NOQA
+
+import gym
+
+
+class Render(gym.Wrapper):
+    """Render env by calling its render method.
+
+    Args:
+        env (gym.Env): Env to wrap.
+        **kwargs: Keyword arguments passed to the render method.
+    """
+
+    def __init__(self, env, **kwargs):
+        super().__init__(env)
+        self._kwargs = kwargs
+
+    def reset(self, **kwargs):
+        ret = self.env.reset(**kwargs)
+        self.env.render(**self._kwargs)
+        return ret
+
+    def step(self, action):
+        ret = self.env.step(action)
+        self.env.render(**self._kwargs)
+        return ret

--- a/examples/ale/train_a2c_ale.py
+++ b/examples/ale/train_a2c_ale.py
@@ -118,7 +118,7 @@ def main():
                 env, args.outdir,
                 mode='evaluation' if test else 'training')
         if args.render:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     def make_batch_env(test):

--- a/examples/ale/train_a3c_ale.py
+++ b/examples/ale/train_a3c_ale.py
@@ -160,7 +160,7 @@ def main():
                 env, args.outdir,
                 mode='evaluation' if test else 'training')
         if args.render:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     if args.demo:

--- a/examples/ale/train_acer_ale.py
+++ b/examples/ale/train_acer_ale.py
@@ -17,6 +17,7 @@ import gym
 import gym.wrappers
 import numpy as np
 
+import chainerrl
 from chainerrl.action_value import DiscreteActionValue
 from chainerrl.agents import acer
 from chainerrl.distribution import SoftmaxDistribution
@@ -141,7 +142,7 @@ def main():
                 env, args.outdir,
                 mode='evaluation' if test else 'training')
         if args.render:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     if args.demo:

--- a/examples/ale/train_categorical_dqn_ale.py
+++ b/examples/ale/train_categorical_dqn_ale.py
@@ -87,7 +87,7 @@ def main():
                 env, args.outdir,
                 mode='evaluation' if test else 'training')
         if args.render:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     env = make_env(test=False)

--- a/examples/ale/train_dqn_ale.py
+++ b/examples/ale/train_dqn_ale.py
@@ -165,7 +165,7 @@ def main():
                 env, args.outdir,
                 mode='evaluation' if test else 'training')
         if args.render:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     env = make_env(test=False)

--- a/examples/ale/train_dqn_batch_ale.py
+++ b/examples/ale/train_dqn_batch_ale.py
@@ -154,7 +154,7 @@ def main():
                 env, args.outdir,
                 mode='evaluation' if test else 'training')
         if args.render:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     def make_batch_env(test):

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -96,7 +96,7 @@ def main():
                 env, args.outdir,
                 mode='evaluation' if test else 'training')
         if args.render:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     sample_env = make_env(0, test=False)

--- a/examples/ale/train_ppo_ale.py
+++ b/examples/ale/train_ppo_ale.py
@@ -12,6 +12,7 @@ import gym
 import gym.wrappers
 import numpy as np
 
+import chainerrl
 from chainerrl.agents.a3c import A3CModel
 from chainerrl.agents import PPO
 from chainerrl import experiments
@@ -102,7 +103,7 @@ def main():
                 env, args.outdir,
                 mode='evaluation' if test else 'training')
         if args.render:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     env = make_env(test=False)

--- a/examples/atari/dqn/train_dqn.py
+++ b/examples/atari/dqn/train_dqn.py
@@ -165,7 +165,7 @@ def main():
                 env, args.outdir,
                 mode='evaluation' if test else 'training')
         if args.render:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     env = make_env(test=False)

--- a/examples/gym/train_a2c_gym.py
+++ b/examples/gym/train_a2c_gym.py
@@ -148,7 +148,7 @@ def main():
             misc.env_modifiers.make_reward_filtered(
                 env, lambda x: x * args.reward_scale_factor)
         if args.render and process_idx == 0 and not test:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     def make_batch_env(test):

--- a/examples/gym/train_a3c_gym.py
+++ b/examples/gym/train_a3c_gym.py
@@ -153,7 +153,7 @@ def main():
             # training is easier
             env = chainerrl.wrappers.ScaleReward(env, args.reward_scale_factor)
         if args.render and process_idx == 0 and not test:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     sample_env = gym.make(args.env)

--- a/examples/gym/train_acer_gym.py
+++ b/examples/gym/train_acer_gym.py
@@ -99,7 +99,7 @@ def main():
             # training is easier
             env = chainerrl.wrappers.ScaleReward(env, args.reward_scale_factor)
         if args.render and process_idx == 0 and not test:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     sample_env = gym.make(args.env)

--- a/examples/gym/train_categorical_dqn_gym.py
+++ b/examples/gym/train_categorical_dqn_gym.py
@@ -88,7 +88,7 @@ def main():
             env = chainerrl.wrappers.ScaleReward(env, args.reward_scale_factor)
         if ((args.render_eval and test) or
                 (args.render_train and not test)):
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     env = make_env(test=False)

--- a/examples/gym/train_ddpg_gym.py
+++ b/examples/gym/train_ddpg_gym.py
@@ -93,7 +93,7 @@ def main():
             # training is easier
             env = chainerrl.wrappers.ScaleReward(env, args.reward_scale_factor)
         if args.render and not test:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     env = make_env(test=False)

--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -104,7 +104,7 @@ def main():
             env = chainerrl.wrappers.ScaleReward(env, args.reward_scale_factor)
         if ((args.render_eval and test) or
                 (args.render_train and not test)):
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     env = make_env(test=False)

--- a/examples/gym/train_pcl_gym.py
+++ b/examples/gym/train_pcl_gym.py
@@ -114,7 +114,7 @@ def main():
             # training is easier
             env = chainerrl.wrappers.ScaleReward(env, args.reward_scale_factor)
         if args.render and process_idx == 0 and not test:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     sample_env = gym.make(args.env)

--- a/examples/gym/train_ppo_batch_gym.py
+++ b/examples/gym/train_ppo_batch_gym.py
@@ -145,7 +145,7 @@ def main():
             # training is easier
             env = chainerrl.wrappers.ScaleReward(env, args.reward_scale_factor)
         if args.render:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     def make_batch_env(test):

--- a/examples/gym/train_ppo_gym.py
+++ b/examples/gym/train_ppo_gym.py
@@ -134,7 +134,7 @@ def main():
             # training is easier
             env = chainerrl.wrappers.ScaleReward(env, args.reward_scale_factor)
         if args.render:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     sample_env = gym.make(args.env)

--- a/examples/gym/train_reinforce_gym.py
+++ b/examples/gym/train_reinforce_gym.py
@@ -76,7 +76,7 @@ def main():
             # training is easier
             env = chainerrl.wrappers.ScaleReward(env, args.reward_scale_factor)
         if args.render and not test:
-            misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     train_env = make_env(test=False)

--- a/examples/gym/train_trpo_gym.py
+++ b/examples/gym/train_trpo_gym.py
@@ -84,7 +84,7 @@ def main():
         if args.monitor:
             env = gym.wrappers.Monitor(env, args.outdir)
         if args.render:
-            chainerrl.misc.env_modifiers.make_rendered(env)
+            env = chainerrl.wrappers.Render(env)
         return env
 
     env = make_env(test=False)

--- a/tests/wrappers_tests/test_render.py
+++ b/tests/wrappers_tests/test_render.py
@@ -1,0 +1,76 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()  # NOQA
+
+import unittest
+
+from chainer import testing
+import mock
+
+import chainerrl
+
+
+@testing.parameterize(*testing.product({
+    'render_kwargs': [
+        {},
+        {'mode': 'human'},
+        {'mode': 'rgb_array'},
+    ]
+}))
+class TestRender(unittest.TestCase):
+
+    def test(self):
+        orig_env = mock.Mock()
+        # Reaches the terminal state after five actions
+        orig_env.reset.side_effect = [
+            ('state', 0),
+            ('state', 3),
+        ]
+        orig_env.step.side_effect = [
+            (('state', 1), 0, False, {}),
+            (('state', 2), 1, True, {}),
+        ]
+        env = chainerrl.wrappers.Render(orig_env, **self.render_kwargs)
+
+        # Not called env.render yet
+        self.assertEqual(orig_env.render.call_count, 0)
+
+        obs = env.reset()
+        self.assertEqual(obs, ('state', 0))
+
+        # Called once
+        self.assertEqual(orig_env.render.call_count, 1)
+
+        obs, reward, done, info = env.step(0)
+        self.assertEqual(obs, ('state', 1))
+        self.assertEqual(reward, 0)
+        self.assertEqual(done, False)
+        self.assertEqual(info, {})
+
+        # Called twice
+        self.assertEqual(orig_env.render.call_count, 2)
+
+        obs, reward, done, info = env.step(0)
+        self.assertEqual(obs, ('state', 2))
+        self.assertEqual(reward, 1)
+        self.assertEqual(done, True)
+        self.assertEqual(info, {})
+
+        # Called thrice
+        self.assertEqual(orig_env.render.call_count, 3)
+
+        obs = env.reset()
+        self.assertEqual(obs, ('state', 3))
+
+        # Called four times
+        self.assertEqual(orig_env.render.call_count, 4)
+
+        # All the calls should receive correct kwargs
+        for call in orig_env.render.call_args_list:
+            args, kwargs = call
+            self.assertEqual(len(args), 0)
+            self.assertEqual(kwargs, self.render_kwargs)


### PR DESCRIPTION
This PR adds `chainerrl.wrappers.Render`, an Env wrapper that calls `env.render` after every `env.reset` and `env.step`. All the examples that uses `chainerrl.misc.env_modifiers.make_rendered` switch to use the new wrapper.

Somehow `chainerrl.misc.env_modifiers.make_rendered` stopped to work correctly for atari environments, and this PR is needed to fix this issue.

I confirmed that all the affected examples work with rendering enabled.