### PR TITLE
Allow envs to send a 'needs_reset' signal

### DIFF
--- a/chainerrl/experiments/evaluator.py
+++ b/chainerrl/experiments/evaluator.py
@@ -104,7 +104,7 @@ def batch_run_evaluation_episodes(
     obss = env.reset()
     rs = np.zeros(num_envs, dtype='f')
 
-    while len(episode_returns) < n_runs:
+    while True:
         # a_t
         actions = agent.batch_act(obss)
         # o_{t+1}, r_{t+1}
@@ -129,6 +129,10 @@ def batch_run_evaluation_episodes(
 
         episode_returns.extend(episode_r[end])
         episode_lengths.extend(episode_len[end])
+
+        if len(episode_returns) >= n_runs:
+            break
+
         episode_r[end] = 0
         episode_len[end] = 0
         obss = env.reset(not_end)

--- a/chainerrl/experiments/evaluator.py
+++ b/chainerrl/experiments/evaluator.py
@@ -117,6 +117,9 @@ def batch_run_evaluation_episodes(
             resets = np.zeros(num_envs, dtype=bool)
         else:
             resets = (episode_len == max_episode_len)
+        resets = np.logical_or(
+            resets, [info.get('needs_reset', False) for info in infos])
+
         # Agent observes the consequences
         agent.batch_observe(obss, rs, dones, resets)
 

--- a/chainerrl/experiments/evaluator.py
+++ b/chainerrl/experiments/evaluator.py
@@ -55,7 +55,10 @@ def run_evaluation_episodes(env, agent, n_runs, max_episode_len=None,
         done = False
         test_r = 0
         t = 0
-        while not (done or t == max_episode_len):
+        info = {}
+        while not (done
+                   or t == max_episode_len
+                   or info.get('needs_reset', False)):
             a = agent.act(obs)
             obs, r, done, info = env.step(a)
             test_r += r

--- a/chainerrl/experiments/train_agent.py
+++ b/chainerrl/experiments/train_agent.py
@@ -59,10 +59,9 @@ def train_agent(agent, env, steps, outdir, max_episode_len=None,
             for hook in step_hooks:
                 hook(env, agent, t)
 
-            if (done
-                    or episode_len == max_episode_len
-                    or t == steps
-                    or info.get('needs_reset', False)):
+            reset = (episode_len == max_episode_len
+                     or info.get('needs_reset', False))
+            if done or reset or t == steps:
                 agent.stop_episode_and_train(obs, r, done=done)
                 logger.info('outdir:%s step:%s episode:%s R:%s',
                             outdir, t, episode_idx, episode_r)

--- a/chainerrl/experiments/train_agent.py
+++ b/chainerrl/experiments/train_agent.py
@@ -59,7 +59,10 @@ def train_agent(agent, env, steps, outdir, max_episode_len=None,
             for hook in step_hooks:
                 hook(env, agent, t)
 
-            if done or episode_len == max_episode_len or t == steps:
+            if (done
+                    or episode_len == max_episode_len
+                    or t == steps
+                    or info.get('needs_reset', False)):
                 agent.stop_episode_and_train(obs, r, done=done)
                 logger.info('outdir:%s step:%s episode:%s R:%s',
                             outdir, t, episode_idx, episode_r)

--- a/chainerrl/experiments/train_agent_async.py
+++ b/chainerrl/experiments/train_agent_async.py
@@ -56,11 +56,9 @@ def train_loop(process_idx, env, agent, steps, outdir, counter,
             for hook in global_step_hooks:
                 hook(env, agent, global_t)
 
-            if (done
-                    or episode_len == max_episode_len
-                    or info.get('needs_reset', False)
-                    or global_t >= steps
-                    or training_done.value):
+            reset = (episode_len == max_episode_len
+                     or info.get('needs_reset', False))
+            if done or reset or global_t >= steps or training_done.value:
                 agent.stop_episode_and_train(obs, r, done)
 
                 if process_idx == 0:

--- a/chainerrl/experiments/train_agent_async.py
+++ b/chainerrl/experiments/train_agent_async.py
@@ -67,7 +67,7 @@ def train_loop(process_idx, env, agent, steps, outdir, counter,
                         outdir, global_t, local_t, episode_r)
                     logger.info('statistics:%s', agent.get_statistics())
 
-                # Evalaute the current agent
+                # Evaluate the current agent
                 if evaluator is not None:
                     eval_score = evaluator.evaluate_if_necessary(
                         t=global_t, episodes=global_episodes,

--- a/chainerrl/experiments/train_agent_batch.py
+++ b/chainerrl/experiments/train_agent_batch.py
@@ -58,7 +58,7 @@ def train_agent_batch(agent, env, steps, outdir, log_interval=None,
         agent.t = step_offset
 
     try:
-        while t < steps:
+        while True:
             # a_t
             actions = agent.batch_act_and_train(obss)
             # o_{t+1}, r_{t+1}
@@ -88,9 +88,6 @@ def train_agent_batch(agent, env, steps, outdir, log_interval=None,
             #   5. reset the env to start a new episode
             episode_idx += end
             recent_returns.extend(episode_r[end])
-            episode_r[end] = 0
-            episode_len[end] = 0
-            obss = env.reset(not_end)
 
             for _ in range(num_envs):
                 t += 1
@@ -115,6 +112,14 @@ def train_agent_batch(agent, env, steps, outdir, log_interval=None,
                     if (successful_score is not None and
                             evaluator.max_score >= successful_score):
                         break
+
+            if t >= steps:
+                break
+
+            # Start new episodes if needed
+            episode_r[end] = 0
+            episode_len[end] = 0
+            obss = env.reset(not_end)
 
     except (Exception, KeyboardInterrupt):
         # Save the current model before being killed

--- a/chainerrl/experiments/train_agent_batch.py
+++ b/chainerrl/experiments/train_agent_batch.py
@@ -86,6 +86,7 @@ def train_agent_batch(agent, env, steps, outdir, log_interval=None,
             #   3. clear the record of rewards
             #   4. clear the record of the number of steps
             #   5. reset the env to start a new episode
+            # 3-5 are skipped when training is already finished.
             episode_idx += end
             recent_returns.extend(episode_r[end])
 

--- a/chainerrl/experiments/train_agent_batch.py
+++ b/chainerrl/experiments/train_agent_batch.py
@@ -71,6 +71,8 @@ def train_agent_batch(agent, env, steps, outdir, log_interval=None,
                 resets = np.zeros(num_envs, dtype=bool)
             else:
                 resets = (episode_len == max_episode_len)
+            resets = np.logical_or(
+                resets, [info.get('needs_reset', False) for info in infos])
             # Agent observes the consequences
             agent.batch_observe_and_train(obss, rs, dones, resets)
 

--- a/chainerrl/wrappers/__init__.py
+++ b/chainerrl/wrappers/__init__.py
@@ -1,6 +1,8 @@
 from chainerrl.wrappers.cast_observation import CastObservation  # NOQA
 from chainerrl.wrappers.cast_observation import CastObservationToFloat32  # NOQA
 
+from chainerrl.wrappers.continuing_time_limit import ContinuingTimeLimit  # NOQA
+
 from chainerrl.wrappers.randomize_action import RandomizeAction  # NOQA
 
 from chainerrl.wrappers.render import Render  # NOQA

--- a/chainerrl/wrappers/atari_wrappers.py
+++ b/chainerrl/wrappers/atari_wrappers.py
@@ -3,8 +3,6 @@ https://github.com/openai/baselines/blob/master/baselines/common/atari_wrappers.
 """
 
 from collections import deque
-import logging
-import time
 
 import cv2
 import gym
@@ -12,9 +10,9 @@ import numpy as np
 
 from gym import spaces
 
-cv2.ocl.setUseOpenCL(False)
+import chainerrl
 
-logger = logging.getLogger(__name__)
+cv2.ocl.setUseOpenCL(False)
 
 
 class NoopResetEnv(gym.Wrapper):
@@ -248,7 +246,8 @@ def make_atari(env_id, max_frames=30 * 60 * 60):
     assert isinstance(env, gym.wrappers.TimeLimit)
     # Unwrap TimeLimit wrapper because we use our own time limits
     env = env.env
-    env = ContinuingTimeLimit(env, max_episode_steps=max_frames)
+    env = chainerrl.wrappers.ContinuingTimeLimit(
+        env, max_episode_steps=max_frames)
     env = NoopResetEnv(env, noop_max=30)
     env = MaxAndSkipEnv(env, skip=4)
     return env

--- a/chainerrl/wrappers/atari_wrappers.py
+++ b/chainerrl/wrappers/atari_wrappers.py
@@ -242,53 +242,6 @@ class LazyFrames(object):
         return out
 
 
-class ContinuingTimeLimit(gym.Wrapper):
-    def __init__(self, env, max_episode_seconds=None, max_episode_steps=None):
-        super(ContinuingTimeLimit, self).__init__(env)
-        self._max_episode_seconds = max_episode_seconds
-        self._max_episode_steps = max_episode_steps
-
-        self._elapsed_steps = 0
-        self._episode_started_at = None
-
-    @property
-    def _elapsed_seconds(self):
-        return time.time() - self._episode_started_at
-
-    def _past_limit(self):
-        """Return true if we are past our limit"""
-        if (self._max_episode_steps is not None
-                and self._max_episode_steps <= self._elapsed_steps):
-            logger.debug("Env has passed the step limit defined by TimeLimit.")
-            return True
-
-        if (self._max_episode_seconds is not None
-                and self._max_episode_seconds <= self._elapsed_seconds):
-            logger.debug(
-                "Env has passed the seconds limit defined by TimeLimit.")
-            return True
-
-        return False
-
-    def _step(self, action):
-        assert self._episode_started_at is not None,\
-            "Cannot call env.step() before calling reset()"
-        observation, reward, done, info = self.env.step(action)
-        self._elapsed_steps += 1
-
-        if self._past_limit():
-            if self.metadata.get('semantics.autoreset'):
-                self.reset()  # automatically reset the env
-            info['needs_reset'] = True
-
-        return observation, reward, done, info
-
-    def _reset(self):
-        self._episode_started_at = time.time()
-        self._elapsed_steps = 0
-        return self.env.reset()
-
-
 def make_atari(env_id, max_frames=30 * 60 * 60):
     env = gym.make(env_id)
     assert 'NoFrameskip' in env.spec.id

--- a/chainerrl/wrappers/continuing_time_limit.py
+++ b/chainerrl/wrappers/continuing_time_limit.py
@@ -16,7 +16,7 @@ class ContinuingTimeLimit(gym.Wrapper):
     each episode, except that done=False is returned and that
     info['needs_reset'] is set to True when past the limit.
 
-    Code that calls env.step is repsonsible for checking the info dict, the
+    Code that calls env.step is responsible for checking the info dict, the
     fourth returned value, and resetting the env if it has the 'needs_reset'
     key and its value is True.
 

--- a/chainerrl/wrappers/continuing_time_limit.py
+++ b/chainerrl/wrappers/continuing_time_limit.py
@@ -1,54 +1,48 @@
-import logging
-import time
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()  # NOQA
 
 import gym
 
 
-logger = logging.getLogger(__name__)
-
-
 class ContinuingTimeLimit(gym.Wrapper):
-    def __init__(self, env, max_episode_seconds=None, max_episode_steps=None):
+    """TimeLimit wrapper for continuing environments.
+
+    This is similar gym.wrappers.TimeLimit, which sets a time limit for
+    each episode, except that done=False is returned and that
+    info['needs_reset'] is set to True when past the limit.
+
+    Code that calls env.step is repsonsible for checking the info dict, the
+    fourth returned value, and resetting the env if it has the 'needs_reset'
+    key and its value is True.
+
+    Args:
+        env (gym.Env): Env to wrap.
+        max_episode_steps (int): Maximum number of timesteps during an episode,
+            after which the env needs a reset.
+    """
+
+    def __init__(self, env, max_episode_steps):
         super(ContinuingTimeLimit, self).__init__(env)
-        self._max_episode_seconds = max_episode_seconds
         self._max_episode_steps = max_episode_steps
 
-        self._elapsed_steps = 0
-        self._episode_started_at = None
+        self._elapsed_steps = None
 
-    @property
-    def _elapsed_seconds(self):
-        return time.time() - self._episode_started_at
-
-    def _past_limit(self):
-        """Return true if we are past our limit"""
-        if (self._max_episode_steps is not None
-                and self._max_episode_steps <= self._elapsed_steps):
-            logger.debug("Env has passed the step limit defined by TimeLimit.")
-            return True
-
-        if (self._max_episode_seconds is not None
-                and self._max_episode_seconds <= self._elapsed_seconds):
-            logger.debug(
-                "Env has passed the seconds limit defined by TimeLimit.")
-            return True
-
-        return False
-
-    def _step(self, action):
-        assert self._episode_started_at is not None,\
+    def step(self, action):
+        assert self._elapsed_steps is not None,\
             "Cannot call env.step() before calling reset()"
         observation, reward, done, info = self.env.step(action)
         self._elapsed_steps += 1
 
-        if self._past_limit():
-            if self.metadata.get('semantics.autoreset'):
-                self.reset()  # automatically reset the env
+        if self._max_episode_steps <= self._elapsed_steps:
             info['needs_reset'] = True
 
         return observation, reward, done, info
 
-    def _reset(self):
-        self._episode_started_at = time.time()
+    def reset(self):
         self._elapsed_steps = 0
         return self.env.reset()

--- a/chainerrl/wrappers/continuing_time_limit.py
+++ b/chainerrl/wrappers/continuing_time_limit.py
@@ -1,0 +1,54 @@
+import logging
+import time
+
+import gym
+
+
+logger = logging.getLogger(__name__)
+
+
+class ContinuingTimeLimit(gym.Wrapper):
+    def __init__(self, env, max_episode_seconds=None, max_episode_steps=None):
+        super(ContinuingTimeLimit, self).__init__(env)
+        self._max_episode_seconds = max_episode_seconds
+        self._max_episode_steps = max_episode_steps
+
+        self._elapsed_steps = 0
+        self._episode_started_at = None
+
+    @property
+    def _elapsed_seconds(self):
+        return time.time() - self._episode_started_at
+
+    def _past_limit(self):
+        """Return true if we are past our limit"""
+        if (self._max_episode_steps is not None
+                and self._max_episode_steps <= self._elapsed_steps):
+            logger.debug("Env has passed the step limit defined by TimeLimit.")
+            return True
+
+        if (self._max_episode_seconds is not None
+                and self._max_episode_seconds <= self._elapsed_seconds):
+            logger.debug(
+                "Env has passed the seconds limit defined by TimeLimit.")
+            return True
+
+        return False
+
+    def _step(self, action):
+        assert self._episode_started_at is not None,\
+            "Cannot call env.step() before calling reset()"
+        observation, reward, done, info = self.env.step(action)
+        self._elapsed_steps += 1
+
+        if self._past_limit():
+            if self.metadata.get('semantics.autoreset'):
+                self.reset()  # automatically reset the env
+            info['needs_reset'] = True
+
+        return observation, reward, done, info
+
+    def _reset(self):
+        self._episode_started_at = time.time()
+        self._elapsed_steps = 0
+        return self.env.reset()

--- a/examples/ale/train_a2c_ale.py
+++ b/examples/ale/train_a2c_ale.py
@@ -53,9 +53,9 @@ def main():
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed [0, 2 ** 31)')
     parser.add_argument('--outdir', type=str, default='results')
-    parser.add_argument('--max-episode-len', type=int,
-                        default=30 * 60 * 60 // 4,  # 30 minutes with 60/4 fps
-                        help='Maximum number of steps for each episode.')
+    parser.add_argument('--max-frames', type=int,
+                        default=30 * 60 * 60,  # 30 minutes with 60 fps
+                        help='Maximum number of frames for each episode.')
     parser.add_argument('--steps', type=int, default=8 * 10 ** 7)
     parser.add_argument('--update-steps', type=int, default=5)
     parser.add_argument('--lr', type=float, default=7e-4)
@@ -109,7 +109,7 @@ def main():
         process_seed = process_seeds[process_idx]
         env_seed = 2 ** 31 - 1 - process_seed if test else process_seed
         env = atari_wrappers.wrap_deepmind(
-            atari_wrappers.make_atari(args.env),
+            atari_wrappers.make_atari(args.env, max_frames=args.max_frames),
             episode_life=not test,
             clip_rewards=not test)
         env.seed(int(env_seed))
@@ -169,7 +169,6 @@ def main():
             eval_interval=args.eval_interval,
             outdir=args.outdir,
             save_best_so_far_agent=False,
-            max_episode_len=args.max_episode_len,
             log_interval=1000,
         )
 

--- a/examples/ale/train_a3c_ale.py
+++ b/examples/ale/train_a3c_ale.py
@@ -76,9 +76,9 @@ def main():
     parser.add_argument('--beta', type=float, default=1e-2)
     parser.add_argument('--profile', action='store_true')
     parser.add_argument('--steps', type=int, default=8 * 10 ** 7)
-    parser.add_argument('--max-episode-len', type=int,
-                        default=5 * 60 * 60 // 4,  # 5 minutes with 60/4 fps
-                        help='Maximum number of steps for each episode.')
+    parser.add_argument('--max-frames', type=int,
+                        default=30 * 60 * 60,  # 30 minutes with 60 fps
+                        help='Maximum number of frames for each episode.')
     parser.add_argument('--lr', type=float, default=7e-4)
     parser.add_argument('--eval-interval', type=int, default=10 ** 6)
     parser.add_argument('--eval-n-runs', type=int, default=10)
@@ -151,7 +151,7 @@ def main():
         process_seed = process_seeds[process_idx]
         env_seed = 2 ** 31 - 1 - process_seed if test else process_seed
         env = atari_wrappers.wrap_deepmind(
-            atari_wrappers.make_atari(args.env),
+            atari_wrappers.make_atari(args.env, max_frames=args.max_frames),
             episode_life=not test,
             clip_rewards=not test)
         env.seed(int(env_seed))
@@ -190,7 +190,6 @@ def main():
             steps=args.steps,
             eval_n_runs=args.eval_n_runs,
             eval_interval=args.eval_interval,
-            max_episode_len=args.max_episode_len,
             global_step_hooks=[lr_decay_hook],
             save_best_so_far_agent=False,
         )

--- a/examples/ale/train_acer_ale.py
+++ b/examples/ale/train_acer_ale.py
@@ -47,9 +47,9 @@ def main():
     parser.add_argument('--beta', type=float, default=1e-2)
     parser.add_argument('--profile', action='store_true')
     parser.add_argument('--steps', type=int, default=10 ** 7)
-    parser.add_argument('--max-episode-len', type=int,
-                        default=5 * 60 * 60 // 4,  # 5 minutes with 60/4 fps
-                        help='Maximum number of steps for each episode.')
+    parser.add_argument('--max-frames', type=int,
+                        default=30 * 60 * 60,  # 30 minutes with 60 fps
+                        help='Maximum number of frames for each episode.')
     parser.add_argument('--lr', type=float, default=7e-4)
     parser.add_argument('--eval-interval', type=int, default=10 ** 5)
     parser.add_argument('--eval-n-runs', type=int, default=10)
@@ -133,7 +133,7 @@ def main():
         process_seed = process_seeds[process_idx]
         env_seed = 2 ** 31 - 1 - process_seed if test else process_seed
         env = atari_wrappers.wrap_deepmind(
-            atari_wrappers.make_atari(args.env),
+            atari_wrappers.make_atari(args.env, max_frames=args.max_frames),
             episode_life=not test,
             clip_rewards=not test)
         env.seed(int(env_seed))
@@ -172,7 +172,6 @@ def main():
             steps=args.steps,
             eval_n_runs=args.eval_n_runs,
             eval_interval=args.eval_interval,
-            max_episode_len=args.max_episode_len,
             global_step_hooks=[lr_decay_hook],
             save_best_so_far_agent=False,
         )

--- a/examples/ale/train_categorical_dqn_ale.py
+++ b/examples/ale/train_categorical_dqn_ale.py
@@ -39,9 +39,9 @@ def main():
     parser.add_argument('--final-epsilon', type=float, default=0.1)
     parser.add_argument('--eval-epsilon', type=float, default=0.05)
     parser.add_argument('--steps', type=int, default=10 ** 7)
-    parser.add_argument('--max-episode-len', type=int,
-                        default=5 * 60 * 60 // 4,  # 5 minutes with 60/4 fps
-                        help='Maximum number of steps for each episode.')
+    parser.add_argument('--max-frames', type=int,
+                        default=30 * 60 * 60,  # 30 minutes with 60 fps
+                        help='Maximum number of frames for each episode.')
     parser.add_argument('--replay-start-size', type=int, default=5 * 10 ** 4)
     parser.add_argument('--target-update-interval',
                         type=int, default=10 ** 4)
@@ -75,7 +75,7 @@ def main():
         # Use different random seeds for train and test envs
         env_seed = test_seed if test else train_seed
         env = atari_wrappers.wrap_deepmind(
-            atari_wrappers.make_atari(args.env),
+            atari_wrappers.make_atari(args.env, max_frames=args.max_frames),
             episode_life=not test,
             clip_rewards=not test)
         env.seed(int(env_seed))
@@ -151,7 +151,6 @@ def main():
             eval_n_runs=args.eval_n_runs, eval_interval=args.eval_interval,
             outdir=args.outdir,
             save_best_so_far_agent=False,
-            max_episode_len=args.max_episode_len,
             eval_env=eval_env,
         )
 

--- a/examples/ale/train_dqn_ale.py
+++ b/examples/ale/train_dqn_ale.py
@@ -103,9 +103,9 @@ def main():
                         help='Network architecture to use.')
     parser.add_argument('--steps', type=int, default=5 * 10 ** 7,
                         help='Total number of timesteps to train the agent.')
-    parser.add_argument('--max-episode-len', type=int,
-                        default=30 * 60 * 60 // 4,  # 30 minutes with 60/4 fps
-                        help='Maximum number of timesteps for each episode.')
+    parser.add_argument('--max-frames', type=int,
+                        default=30 * 60 * 60,  # 30 minutes with 60 fps
+                        help='Maximum number of frames for each episode.')
     parser.add_argument('--replay-start-size', type=int, default=5 * 10 ** 4,
                         help='Minimum replay buffer size before ' +
                         'performing gradient updates.')
@@ -153,7 +153,7 @@ def main():
         # Use different random seeds for train and test envs
         env_seed = test_seed if test else train_seed
         env = atari_wrappers.wrap_deepmind(
-            atari_wrappers.make_atari(args.env),
+            atari_wrappers.make_atari(args.env, max_frames=args.max_frames),
             episode_life=not test,
             clip_rewards=not test)
         env.seed(int(env_seed))

--- a/examples/ale/train_dqn_ale.py
+++ b/examples/ale/train_dqn_ale.py
@@ -234,7 +234,6 @@ def main():
             eval_n_runs=args.eval_n_runs, eval_interval=args.eval_interval,
             outdir=args.outdir,
             save_best_so_far_agent=False,
-            max_episode_len=args.max_episode_len,
             eval_env=eval_env,
         )
 

--- a/examples/ale/train_dqn_batch_ale.py
+++ b/examples/ale/train_dqn_batch_ale.py
@@ -94,9 +94,9 @@ def main():
     parser.add_argument('--arch', type=str, default='doubledqn',
                         choices=['nature', 'nips', 'dueling', 'doubledqn'])
     parser.add_argument('--steps', type=int, default=5 * 10 ** 7)
-    parser.add_argument('--max-episode-len', type=int,
-                        default=30 * 60 * 60 // 4,  # 30 minutes with 60/4 fps
-                        help='Maximum number of steps for each episode.')
+    parser.add_argument('--max-frames', type=int,
+                        default=30 * 60 * 60,  # 30 minutes with 60 fps
+                        help='Maximum number of frames for each episode.')
     parser.add_argument('--replay-start-size', type=int, default=5 * 10 ** 4)
     parser.add_argument('--target-update-interval',
                         type=int, default=3 * 10 ** 4)
@@ -142,7 +142,7 @@ def main():
         process_seed = int(process_seeds[idx])
         env_seed = 2 ** 32 - 1 - process_seed if test else process_seed
         env = atari_wrappers.wrap_deepmind(
-            atari_wrappers.make_atari(args.env),
+            atari_wrappers.make_atari(args.env, max_frames=args.max_frames),
             episode_life=not test,
             clip_rewards=not test)
         if test:
@@ -231,7 +231,6 @@ def main():
             eval_interval=args.eval_interval,
             outdir=args.outdir,
             save_best_so_far_agent=False,
-            max_episode_len=args.max_episode_len,
             log_interval=1000,
         )
 

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -40,9 +40,9 @@ def main():
                         help='Random seed [0, 2 ** 31)')
     parser.add_argument('--lr', type=float, default=7e-4)
     parser.add_argument('--steps', type=int, default=8 * 10 ** 7)
-    parser.add_argument('--max-episode-len', type=int,
-                        default=5 * 60 * 60 // 4,  # 5 minutes with 60/4 fps
-                        help='Maximum number of steps for each episode.')
+    parser.add_argument('--max-frames', type=int,
+                        default=30 * 60 * 60,  # 30 minutes with 60 fps
+                        help='Maximum number of frames for each episode.')
     parser.add_argument('--final-exploration-frames',
                         type=int, default=4 * 10 ** 6)
     parser.add_argument('--outdir', type=str, default='results',
@@ -84,7 +84,7 @@ def main():
         process_seed = process_seeds[process_idx]
         env_seed = 2 ** 31 - 1 - process_seed if test else process_seed
         env = atari_wrappers.wrap_deepmind(
-            atari_wrappers.make_atari(args.env),
+            atari_wrappers.make_atari(args.env, max_frames=args.max_frames),
             episode_life=not test,
             clip_rewards=not test)
         env.seed(int(env_seed))
@@ -161,7 +161,6 @@ def main():
             steps=args.steps,
             eval_n_runs=args.eval_n_runs,
             eval_interval=args.eval_interval,
-            max_episode_len=args.max_episode_len,
             global_step_hooks=[lr_decay_hook],
             save_best_so_far_agent=False,
         )

--- a/examples/ale/train_ppo_ale.py
+++ b/examples/ale/train_ppo_ale.py
@@ -49,9 +49,9 @@ def main():
                         help='Directory path to save output files.'
                              ' If it does not exist, it will be created.')
     parser.add_argument('--steps', type=int, default=10 ** 7)
-    parser.add_argument('--max-episode-len', type=int,
-                        default=5 * 60 * 60 // 4,  # 5 minutes with 60/4 fps
-                        help='Maximum number of steps for each episode.')
+    parser.add_argument('--max-frames', type=int,
+                        default=30 * 60 * 60,  # 30 minutes with 60 fps
+                        help='Maximum number of frames for each episode.')
     parser.add_argument('--lr', type=float, default=2.5e-4)
 
     parser.add_argument('--eval-interval', type=int, default=10 ** 5)
@@ -94,7 +94,7 @@ def main():
         # Use different random seeds for train and test envs
         env_seed = test_seed if test else train_seed
         env = atari_wrappers.wrap_deepmind(
-            atari_wrappers.make_atari(args.env),
+            atari_wrappers.make_atari(args.env, max_frames=args.max_frames),
             episode_life=not test,
             clip_rewards=not test)
         env.seed(int(env_seed))
@@ -165,7 +165,6 @@ def main():
             steps=args.steps,
             eval_n_runs=args.eval_n_runs,
             eval_interval=args.eval_interval,
-            max_episode_len=args.max_episode_len,
             save_best_so_far_agent=False,
             step_hooks=[
                 lr_decay_hook,

--- a/examples/atari/dqn/train_dqn.py
+++ b/examples/atari/dqn/train_dqn.py
@@ -53,9 +53,9 @@ def main():
                         help='Network architecture to use.')
     parser.add_argument('--steps', type=int, default=5 * 10 ** 7,
                         help='Total number of timesteps to train the agent.')
-    parser.add_argument('--max-episode-len', type=int,
-                        default=30 * 60 * 60 // 4,  # 30 minutes with 60/4 fps
-                        help='Maximum number of timesteps for each episode.')
+    parser.add_argument('--max-frames', type=int,
+                        default=30 * 60 * 60,  # 30 minutes with 60 fps
+                        help='Maximum number of frames for each episode.')
     parser.add_argument('--replay-start-size', type=int, default=5 * 10 ** 4,
                         help='Minimum replay buffer size before ' +
                         'performing gradient updates.')
@@ -100,7 +100,7 @@ def main():
         # Use different random seeds for train and test envs
         env_seed = test_seed if test else train_seed
         env = atari_wrappers.wrap_deepmind(
-            atari_wrappers.make_atari(args.env),
+            atari_wrappers.make_atari(args.env, max_frames=args.max_frames),
             episode_life=not test,
             clip_rewards=not test)
         env.seed(int(env_seed))
@@ -177,7 +177,6 @@ def main():
             eval_n_episodes=args.eval_n_runs, eval_interval=args.eval_interval,
             outdir=args.outdir,
             save_best_so_far_agent=False,
-            train_max_episode_len=args.max_episode_len,
             eval_env=eval_env,
         )
 

--- a/tests/experiments_tests/test_evaluator.py
+++ b/tests/experiments_tests/test_evaluator.py
@@ -148,7 +148,8 @@ class TestRunEvaluationEpisode(unittest.TestCase):
     def test_needs_reset(self):
         agent = mock.Mock()
         env = mock.Mock()
-        # Reaches the terminal state after five actions
+        # First episode: 0 -> 1 -> 2 -> 3 (reset)
+        # Second episode: 4 -> 5 -> 6 -> 7 (done)
         env.reset.side_effect = [('state', 0), ('state', 4)]
         env.step.side_effect = [
             (('state', 1), 0, False, {}),

--- a/tests/experiments_tests/test_train_agent.py
+++ b/tests/experiments_tests/test_train_agent.py
@@ -53,3 +53,43 @@ class TestTrainAgent(unittest.TestCase):
             self.assertEqual(args[1], agent)
             # step starts with 1
             self.assertEqual(args[2], i + 1)
+
+    def test_needs_reset(self):
+
+        outdir = tempfile.mkdtemp()
+
+        agent = mock.Mock()
+        env = mock.Mock()
+        # Reaches the terminal state after five actions
+        env.reset.side_effect = [('state', 0), ('state', 4)]
+        env.step.side_effect = [
+            (('state', 1), 0, False, {}),
+            (('state', 2), 0, False, {}),
+            (('state', 3), 0, False, {'needs_reset': True}),
+            (('state', 5), -0.5, False, {}),
+            (('state', 6), 0, False, {}),
+            (('state', 7), 1, True, {}),
+        ]
+        hook = mock.Mock()
+
+        chainerrl.experiments.train_agent(
+            agent=agent,
+            env=env,
+            steps=5,
+            outdir=outdir,
+            step_hooks=[hook])
+
+        self.assertEqual(agent.act_and_train.call_count, 5)
+        self.assertEqual(agent.stop_episode_and_train.call_count, 2)
+
+        self.assertEqual(env.reset.call_count, 2)
+        self.assertEqual(env.step.call_count, 5)
+
+        self.assertEqual(hook.call_count, 5)
+        # A hook receives (env, agent, step)
+        for i, call in enumerate(hook.call_args_list):
+            args, kwargs = call
+            self.assertEqual(args[0], env)
+            self.assertEqual(args[1], agent)
+            # step starts with 1
+            self.assertEqual(args[2], i + 1)

--- a/tests/experiments_tests/test_train_agent.py
+++ b/tests/experiments_tests/test_train_agent.py
@@ -60,7 +60,8 @@ class TestTrainAgent(unittest.TestCase):
 
         agent = mock.Mock()
         env = mock.Mock()
-        # Reaches the terminal state after five actions
+        # First episode: 0 -> 1 -> 2 -> 3 (reset)
+        # Second episode: 4 -> 5 -> 6 -> 7 (done)
         env.reset.side_effect = [('state', 0), ('state', 4)]
         env.step.side_effect = [
             (('state', 1), 0, False, {}),

--- a/tests/experiments_tests/test_train_agent_async.py
+++ b/tests/experiments_tests/test_train_agent_async.py
@@ -116,7 +116,8 @@ class TestTrainLoop(unittest.TestCase):
 
         agent = mock.Mock()
         env = mock.Mock()
-        # Reaches the terminal state after five actions
+        # First episode: 0 -> 1 -> 2 -> 3 (reset)
+        # Second episode: 4 -> 5 -> 6 -> 7 (done)
         env.reset.side_effect = [('state', 0), ('state', 4)]
         env.step.side_effect = [
             (('state', 1), 0, False, {}),

--- a/tests/experiments_tests/test_train_agent_async.py
+++ b/tests/experiments_tests/test_train_agent_async.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from builtins import *  # NOQA
 from future import standard_library
 standard_library.install_aliases()  # NOQA
+import multiprocessing as mp
 import os
 import tempfile
 import unittest
@@ -13,6 +14,7 @@ from chainer import testing
 import mock
 
 import chainerrl
+from chainerrl.experiments.train_agent_async import train_loop
 
 
 @testing.parameterize(*testing.product({
@@ -104,3 +106,43 @@ class TestTrainAgentAsync(unittest.TestCase):
         # Agent should be saved
         agent.save.assert_called_once_with(
             os.path.join(outdir, '{}_finish'.format(steps)))
+
+
+class TestTrainLoop(unittest.TestCase):
+
+    def test_needs_reset(self):
+
+        outdir = tempfile.mkdtemp()
+
+        agent = mock.Mock()
+        env = mock.Mock()
+        # Reaches the terminal state after five actions
+        env.reset.side_effect = [('state', 0), ('state', 4)]
+        env.step.side_effect = [
+            (('state', 1), 0, False, {}),
+            (('state', 2), 0, False, {}),
+            (('state', 3), 0, False, {'needs_reset': True}),
+            (('state', 5), -0.5, False, {}),
+            (('state', 6), 0, False, {}),
+            (('state', 7), 1, True, {}),
+        ]
+
+        counter = mp.Value('i', 0)
+        episodes_counter = mp.Value('i', 0)
+        training_done = mp.Value('b', False)  # bool
+        train_loop(
+            process_idx=0,
+            env=env,
+            agent=agent,
+            steps=5,
+            outdir=outdir,
+            counter=counter,
+            episodes_counter=episodes_counter,
+            training_done=training_done,
+        )
+
+        self.assertEqual(agent.act_and_train.call_count, 5)
+        self.assertEqual(agent.stop_episode_and_train.call_count, 2)
+
+        self.assertEqual(env.reset.call_count, 2)
+        self.assertEqual(env.step.call_count, 5)

--- a/tests/experiments_tests/test_train_agent_batch.py
+++ b/tests/experiments_tests/test_train_agent_batch.py
@@ -23,7 +23,7 @@ class TestTrainAgentBatch(unittest.TestCase):
 
     def test(self):
 
-        steps = 5
+        steps = 6
 
         outdir = tempfile.mkdtemp()
 

--- a/tests/wrappers_tests/test_continuing_time_limit.py
+++ b/tests/wrappers_tests/test_continuing_time_limit.py
@@ -1,0 +1,45 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()  # NOQA
+
+import mock
+import unittest
+
+from chainer import testing
+
+import chainerrl
+
+
+@testing.parameterize(*testing.product({
+    'max_episode_steps': [1, 2, 3],
+}))
+class TestContinuingTimeLimit(unittest.TestCase):
+
+    def test(self):
+        env = mock.Mock()
+        env.reset.side_effect = ['state'] * 2
+        # Since info dicts are modified by the wapper, each step call needs to
+        # return a new info dict.
+        env.step.side_effect = [('state', 0, False, {}) for _ in range(6)]
+        env = chainerrl.wrappers.ContinuingTimeLimit(
+            env, max_episode_steps=self.max_episode_steps)
+
+        env.reset()
+        for t in range(2):
+            _, _, done, info = env.step(0)
+            if t + 1 >= self.max_episode_steps:
+                self.assertTrue(info['needs_reset'])
+            else:
+                self.assertFalse(info.get('needs_reset', False))
+
+        env.reset()
+        for t in range(4):
+            _, _, done, info = env.step(0)
+            if t + 1 >= self.max_episode_steps:
+                self.assertTrue(info['needs_reset'])
+            else:
+                self.assertFalse(info.get('needs_reset', False))


### PR DESCRIPTION
This PR enables an env to send a signal that indicates it needs a reset via the `info` dict returned by `env.step` without setting `done=True`.

This functionality is needed to implement to strictly follow the training protocol of DeepMind on Atari games, which limits the number of frames of an episode ignoring life losses, while the agent still sees episodes that terminate by a life loss.

- [x] add ContinuingTimeLimit wrapper
- [x] handle needs_reset signal in both training and evaluation
- [x] check how it affects DQN on Atari