### PR TITLE
Add long description for pypi 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include LICENSE

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img src="assets/ChainerRL.png" width="400"/></div>
+<div align="center"><img src="https://raw.githubusercontent.com/chainer/chainerrl/master/assets/ChainerRL.png" width="400"/></div>
 
 # ChainerRL
 [![Build Status](https://travis-ci.org/chainer/chainerrl.svg?branch=master)](https://travis-ci.org/chainer/chainerrl)
@@ -8,8 +8,8 @@
 
 ChainerRL is a deep reinforcement learning library that implements various state-of-the-art deep reinforcement algorithms in Python using [Chainer](https://github.com/pfnet/chainer), a flexible deep learning framework.
 
-![Breakout](assets/breakout.gif)
-![Humanoid](assets/humanoid.gif)
+![Breakout](https://raw.githubusercontent.com/chainer/chainerrl/master/assets/breakout.gif)
+![Humanoid](https://raw.githubusercontent.com/chainer/chainerrl/master/assets/humanoid.gif)
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ if sys.version_info < (3, 5):
 setup(name='chainerrl',
       version='0.5.0',
       description='ChainerRL, a deep reinforcement learning library',
+      long_description=open('README.md').read(),
+      long_description_content_type='text/markdown',
       author='Yasuhiro Fujita',
       author_email='fujita@preferred.jp',
       license='MIT License',


### PR DESCRIPTION
Reference: #355 

## Description

Changed the following files:
- `setup.py`: use `README.md` as basis for PyPI project description
- `MANIFEST.in`: includes `LICENSE` and `README.md`
- `README.md`: use raw github content for assets (logo, gifs) instead of relative paths