### PR TITLE
Avoid UnicodeDecodeError in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import codecs
 from setuptools import find_packages
 from setuptools import setup
 import sys
@@ -28,7 +29,7 @@ if sys.version_info < (3, 5):
 setup(name='chainerrl',
       version='0.5.0',
       description='ChainerRL, a deep reinforcement learning library',
-      long_description=open('README.md').read(),
+      long_description=codecs.open('README.md', 'r', encoding='utf-8').read(),
       long_description_content_type='text/markdown',
       author='Yasuhiro Fujita',
       author_email='fujita@preferred.jp',


### PR DESCRIPTION
`pip install -e .` raises `UnicodeDecodeError` when `LC_CTYPE` is `POSIX`.
```
      Traceback (most recent call last):
        File "<string>", line 1, in <module>
        File "/home/user/setup.py", line 31, in <module>
          long_description=open('README.md').read(),
        File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
          return codecs.ascii_decode(input, self.errors)[0]
      UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2004: ordinal not in range(128)
```

To reproduce this error, `LC_ALL=POSIX pip install -e .`.

This PR fixes this error by specifying the encoding when reading README.md.