### PR TITLE
Use chainer.dataset.concat_examples in batch_states

### DIFF
--- a/chainerrl/misc/batch_states.py
+++ b/chainerrl/misc/batch_states.py
@@ -1,3 +1,6 @@
+import chainer
+
+
 def batch_states(states, xp, phi):
     """The default method for making batch of observations.
 
@@ -9,6 +12,12 @@ def batch_states(states, xp, phi):
     Return:
         the object which will be given as input to the model.
     """
+    if xp is chainer.cuda.cupy:
+        # GPU
+        device = chainer.cuda.Device().id
+    else:
+        # CPU
+        device = -1
 
-    states = [phi(s) for s in states]
-    return xp.asarray(states)
+    features = [phi(s) for s in states]
+    return chainer.dataset.concat_examples(features, device=device)

--- a/chainerrl/misc/batch_states.py
+++ b/chainerrl/misc/batch_states.py
@@ -12,7 +12,7 @@ def batch_states(states, xp, phi):
     Return:
         the object which will be given as input to the model.
     """
-    if xp is chainer.cuda.cupy:
+    if chainer.cuda.available and xp is chainer.cuda.cupy:
         # GPU
         device = chainer.cuda.Device().id
     else:

--- a/tests/misc_tests/test_batch_states.py
+++ b/tests/misc_tests/test_batch_states.py
@@ -1,0 +1,58 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()  # NOQA
+import unittest
+
+import chainer
+from chainer import testing
+import numpy as np
+
+import chainerrl
+
+
+class TestBatchStates(unittest.TestCase):
+
+    def _test(self, xp):
+
+        # state: ((2,2)-shaped array, integer, (1,)-shaped array)
+        states = [
+            (np.arange(4).reshape((2, 2)), 0, np.zeros(1)),
+            (np.arange(4).reshape((2, 2)) + 1, 1, np.zeros(1) + 1),
+        ]
+
+        def phi(state):
+            return state[0] * 2, state[1], state[2] * 3
+
+        batch = chainerrl.misc.batch_states(states, xp=xp, phi=phi)
+        self.assertIsInstance(batch, tuple)
+        batch_a, batch_b, batch_c = batch
+        xp.testing.assert_allclose(
+            batch_a,
+            xp.asarray([
+                [[0, 2],
+                 [4, 6]],
+                [[2, 4],
+                 [6, 8]],
+            ])
+        )
+        xp.testing.assert_allclose(
+            batch_b,
+            xp.asarray([0, 1])
+        )
+        xp.testing.assert_allclose(
+            batch_c,
+            xp.asarray([
+                [0],
+                [3],
+            ])
+        )
+
+    def test_cpu(self):
+        self._test(np)
+
+    @testing.attr.gpu
+    def test_gpu(self):
+        self._test(chainer.cuda.cupy)


### PR DESCRIPTION
This change enables the default batch_states function to handle tuple-shaped observations.

I'm running the whole tests.