### PR TITLE
A small change to the installation documentation

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,8 +16,10 @@ ChainerRL can be installed via PyPI:
 
  pip install chainerrl
 
-It can also be installed from the source code:
+The recommended way to install ChainerRL is through the source code:
 
 ::
 
+ git clone https://github.com/chainer/chainerrl.git
+ cd chainerrl
  python setup.py install

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,13 +10,13 @@ ChainerRL is tested with Python 2.7+ and 3.5.1+. For other requirements, see ``r
 .. literalinclude:: ../requirements.txt
   :caption: requirements.txt
 
-ChainerRL can be installed via PyPI:
+ChainerRL can be installed via PyPI,
 
 ::
 
  pip install chainerrl
 
-The recommended way to install ChainerRL is through the source code:
+or through the source code:
 
 ::
 


### PR DESCRIPTION
A small change in the installation documentation. This PR simply expands the instructions on how to install ChainerRL from the source code.