### PR TITLE
Use AbnormalExitCodeWarning for nonzero exitcode warnings

### DIFF
--- a/chainerrl/misc/async_.py
+++ b/chainerrl/misc/async_.py
@@ -15,7 +15,7 @@ import numpy as np
 from chainerrl.misc import random_seed
 
 
-class AbnormalExitCodeWarning(Warning):
+class AbnormalExitWarning(Warning):
     """Warning category for abnormal subprocess exit."""
     pass
 
@@ -142,13 +142,13 @@ def run_async(n_process, run_func):
             warnings.warn(
                 "Process #{} (pid={}) exited with nonzero status {}".format(
                     process_idx, p.pid, p.exitcode),
-                category=AbnormalExitCodeWarning,
+                category=AbnormalExitWarning,
             )
         elif p.exitcode < 0:
             warnings.warn(
                 "Process #{} (pid={}) was terminated by signal {}".format(
                     process_idx, p.pid, -p.exitcode),
-                category=AbnormalExitCodeWarning,
+                category=AbnormalExitWarning,
             )
 
 

--- a/chainerrl/misc/async_.py
+++ b/chainerrl/misc/async_.py
@@ -15,6 +15,11 @@ import numpy as np
 from chainerrl.misc import random_seed
 
 
+class AbnormalExitCodeWarning(Warning):
+    """Warning category for abnormal subprocess exit."""
+    pass
+
+
 def ensure_initialized_update_rule(param):
     u = param.update_rule
     if u.state is None:
@@ -136,11 +141,15 @@ def run_async(n_process, run_func):
         if p.exitcode > 0:
             warnings.warn(
                 "Process #{} (pid={}) exited with nonzero status {}".format(
-                    process_idx, p.pid, p.exitcode))
+                    process_idx, p.pid, p.exitcode),
+                category=AbnormalExitCodeWarning,
+            )
         elif p.exitcode < 0:
             warnings.warn(
                 "Process #{} (pid={}) was terminated by signal {}".format(
-                    process_idx, p.pid, -p.exitcode))
+                    process_idx, p.pid, -p.exitcode),
+                category=AbnormalExitCodeWarning,
+            )
 
 
 def as_shared_objects(obj):

--- a/tests/agents_tests/test_nsq.py
+++ b/tests/agents_tests/test_nsq.py
@@ -19,6 +19,7 @@ import chainerrl
 from chainerrl.agents import nsq
 from chainerrl.envs.abc import ABC
 from chainerrl.experiments.train_agent_async import train_agent_async
+from chainerrl.misc import async_
 from chainerrl.optimizers import rmsprop_async
 from chainerrl.q_functions import FCLSTMStateQFunction
 from chainerrl.q_functions import FCStateQFunctionWithDiscreteAction
@@ -108,7 +109,11 @@ class TestNSQ(unittest.TestCase):
                 eval_n_runs=5,
                 successful_score=1,
             )
-            assert len(warns) == 0, warns[0]
+            # There should be no AbnormalExitCodeWarning
+            self.assertEqual(
+                sum(1 if issubclass(
+                    w.category, async_.AbnormalExitCodeWarning) else 0
+                    for w in warns), 0)
 
         # The agent returned by train_agent_async is not guaranteed to be
         # successful because parameters could be modified by other processes

--- a/tests/agents_tests/test_nsq.py
+++ b/tests/agents_tests/test_nsq.py
@@ -109,10 +109,10 @@ class TestNSQ(unittest.TestCase):
                 eval_n_runs=5,
                 successful_score=1,
             )
-            # There should be no AbnormalExitCodeWarning
+            # There should be no AbnormalExitWarning
             self.assertEqual(
                 sum(1 if issubclass(
-                    w.category, async_.AbnormalExitCodeWarning) else 0
+                    w.category, async_.AbnormalExitWarning) else 0
                     for w in warns), 0)
 
         # The agent returned by train_agent_async is not guaranteed to be

--- a/tests/misc_tests/test_async.py
+++ b/tests/misc_tests/test_async.py
@@ -203,16 +203,16 @@ class TestAsync(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as ws:
             async_.run_async(4, run_with_exit_code_0)
-            # There should be no AbnormalExitCodeWarning
+            # There should be no AbnormalExitWarning
             self.assertEqual(
                 sum(1 if issubclass(
-                    w.category, async_.AbnormalExitCodeWarning) else 0
+                    w.category, async_.AbnormalExitWarning) else 0
                     for w in ws), 0)
 
         with warnings.catch_warnings(record=True) as ws:
             async_.run_async(4, run_with_exit_code_11)
-            # There should be 4 AbnormalExitCodeWarning
+            # There should be 4 AbnormalExitWarning
             self.assertEqual(
                 sum(1 if issubclass(
-                    w.category, async_.AbnormalExitCodeWarning) else 0
+                    w.category, async_.AbnormalExitWarning) else 0
                     for w in ws), 4)

--- a/tests/misc_tests/test_async.py
+++ b/tests/misc_tests/test_async.py
@@ -201,12 +201,18 @@ class TestAsync(unittest.TestCase):
         def run_with_exit_code_11(process_idx):
             os.kill(os.getpid(), signal.SIGSEGV)
 
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as ws:
             async_.run_async(4, run_with_exit_code_0)
-            # There should be no warnings
-            assert len(w) == 0
+            # There should be no AbnormalExitCodeWarning
+            self.assertEqual(
+                sum(1 if issubclass(
+                    w.category, async_.AbnormalExitCodeWarning) else 0
+                    for w in ws), 0)
 
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as ws:
             async_.run_async(4, run_with_exit_code_11)
-            # There should be 4 warnings
-            assert len(w) == 4
+            # There should be 4 AbnormalExitCodeWarning
+            self.assertEqual(
+                sum(1 if issubclass(
+                    w.category, async_.AbnormalExitCodeWarning) else 0
+                    for w in ws), 4)


### PR DESCRIPTION
When subprocesses exit with nonzero exitcode, `run_async` raise warnings. Some tests check the number of warnings, but they do not work when there is another code that raises warnings, leading to failure in CI of current master.

This PR specifies a warning category for nonzero exitcode, `AbnormalExitCodeWarning`, and the tests will check warnings of that category.