### PR TITLE
Avoid random test failures due to asynchronousness

### DIFF
--- a/tests/experiments_tests/test_train_agent_async.py
+++ b/tests/experiments_tests/test_train_agent_async.py
@@ -107,8 +107,18 @@ class TestTrainAgentAsync(unittest.TestCase):
             args, kwargs = call
             self.assertTrue(any(args[0] == env for env in envs))
             self.assertEqual(args[1], agent)
-            # step starts with 1
-            self.assertEqual(args[2], i + 1)
+            if self.num_envs == 1:
+                # If num_envs == 1, a hook should be called sequentially.
+                # step starts with 1
+                self.assertEqual(args[2], i + 1)
+        if self.num_envs > 1:
+            # If num_envs > 1, a hook may not be called sequentially.
+            # Thus, we only check if they are called for each step.
+            hook_steps = [call[0][2] for call in hook.call_args_list]
+            self.assertEqual(
+                list(range(1, len(hook.call_args_list) + 1)),
+                list(sorted(hook_steps)),
+            )
 
         # Agent should be saved
         agent.save.assert_called_once_with(


### PR DESCRIPTION
Asynchronousness in `test_train_agent_async.py` randomly causes CI failures (https://travis-ci.org/chainer/chainerrl/jobs/476783858). This PR fixes this issue.

To reproduce this issue on my local machine, I manually added this change:
```
--- a/tests/experiments_tests/test_train_agent_async.py
+++ b/tests/experiments_tests/test_train_agent_async.py
@@ -71,7 +71,11 @@ class TestTrainAgentAsync(unittest.TestCase):
         hook_lock = threading.Lock()
         hook = mock.Mock()

+        import time
+        import numpy as np
+
         def hook_locked(*args, **kwargs):
+            time.sleep(np.random.uniform(0, 0.01))
             with hook_lock:
                 return hook(*args, **kwargs)
```
With this change, the old test failed, while the new test passed.