### PR TITLE
Drop hacking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   # atari_py==0.1.4 causes an error
   - pip install atari_py==0.1.1
   - pip install autopep8
-  - pip install hacking
+  - pip install flake8
   - pip install coveralls
   - pip install opencv-python
   - pip install pybullet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,9 @@ To test examples, run `test_examples.sh [gpu device id]`. `-1` would run example
 
 ## Coding style
 
-We use PEP8. To check your code, use `autopep8` and `flake8` command installed by `hacking` package.
+We use PEP8. To check your code, use `autopep8` and `flake8` packages.
 ```
-$ pip install autopep8 hacking
+$ pip install autopep8 flake8
 $ autopep8 --diff path/to/your/code.py
 $ flake8 path/to/your/code.py
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 autopep8
 atari_py
-hacking
+flake8
 mock
 opencv-python
 pytest


### PR DESCRIPTION
Currently, `pipenv install -r requirements-dev.txt` fails due to version inconsistency of `pycodestyle` caused by `hacking`:
- autopep8==1.4.3 requires pycodestyle>=2.4.0
- hacking==1.1.0 requires flake8<2.7.0,>=2.6.0
- flake8==2.6.2 requires pycodestyle<2.1,>=2.0

This PR drops `hacking` so we use `flake8` instead.

Chainer already dropped `hacking` https://github.com/chainer/chainer/pull/4864