### PR TITLE
bug fix

### DIFF
--- a/chainerrl/experiments/prepare_output_dir.py
+++ b/chainerrl/experiments/prepare_output_dir.py
@@ -78,6 +78,8 @@ def prepare_output_dir(args, user_specified_dir=None, argv=None,
 
     # Save the command
     with open(os.path.join(outdir, 'command.txt'), 'w') as f:
+        if argv is None:
+            argv = sys.argv
         f.write(' '.join(argv))
 
     if is_under_git_control():

--- a/chainerrl/experiments/prepare_output_dir.py
+++ b/chainerrl/experiments/prepare_output_dir.py
@@ -78,7 +78,7 @@ def prepare_output_dir(args, user_specified_dir=None, argv=None,
 
     # Save the command
     with open(os.path.join(outdir, 'command.txt'), 'w') as f:
-        f.write(' '.join(sys.argv))
+        f.write(' '.join(argv))
 
     if is_under_git_control():
         # Save `git rev-parse HEAD` (SHA of the current commit)


### PR DESCRIPTION
Even if 'argv' was given as an argument, 'sys.argv' was used.