### PR TITLE
Reduce ACER's test cases and maximum timesteps

### DIFF
--- a/tests/agents_tests/test_acer.py
+++ b/tests/agents_tests/test_acer.py
@@ -334,7 +334,7 @@ class TestEfficientTRPO(unittest.TestCase):
     testing.product({
         'discrete': [True, False],
         't_max': [5],
-        'use_lstm': [True, False],
+        'use_lstm': [True],
         'episodic': [True, False],
         'n_times_replay': [0, 2],
         'disable_online_update': [True, False],
@@ -357,7 +357,7 @@ class TestACER(unittest.TestCase):
                        episodic=self.episodic, steps=10, require_success=False)
 
     def _test_abc(self, t_max, use_lstm, discrete=True, episodic=True,
-                  steps=1000000, require_success=True):
+                  steps=100000, require_success=True):
 
         nproc = 8
 
@@ -461,7 +461,7 @@ class TestACER(unittest.TestCase):
         beta = 1e-5
         if self.n_times_replay == 0 and self.disable_online_update:
             # At least one of them must be enabled
-            self.disable_online_update = False
+            return
         agent = acer.ACER(
             model, opt, replay_buffer=replay_buffer,
             t_max=t_max, gamma=gamma, beta=beta,


### PR DESCRIPTION
- `use_lstm=False` was tested for `t_max=1,2,5`. This PR changes it to `t_max=1,2` because I think it is sufficient. `use_lstm=True=True` is tested for `t_max=5` as before.
- Test cases where `n_times_replay=0` and `disable_online_update=True` were tested twice. This PR skips one of them.
- Maximum of timesteps is reduced to avoid consuming too much time on failed tests.