### PR TITLE
Use Python 3.6 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 cache: pip
 python:
   - "2.7"
-  - "3.5.1"
+  - "3.6"
 env:
   - CHAINER_VERSION=3
   - CHAINER_VERSION=stable


### PR DESCRIPTION
This PR fixes the error of `from typing import Type` in Travis CI caused by `tornado==6.0.1` by switching from Python 3.5 to 3.6.

https://travis-ci.org/chainer/chainerrl/jobs/504242079