### PR TITLE
Fixes error in setting explorer in DQN ALE example.

### DIFF
--- a/examples/ale/train_dqn_ale.py
+++ b/examples/ale/train_dqn_ale.py
@@ -181,9 +181,9 @@ def main():
         explorer = explorers.Greedy()
     else:
         explorer = explorers.LinearDecayEpsilonGreedy(
-        1.0, args.final_epsilon,
-        args.final_exploration_frames,
-        lambda: np.random.randint(n_actions))
+            1.0, args.final_epsilon,
+            args.final_exploration_frames,
+            lambda: np.random.randint(n_actions))
 
     # Draw the computational graph and save it in the output directory.
     chainerrl.misc.draw_computational_graph(

--- a/examples/ale/train_dqn_ale.py
+++ b/examples/ale/train_dqn_ale.py
@@ -179,6 +179,11 @@ def main():
         links.to_factorized_noisy(q_func)
         # Turn off explorer
         explorer = explorers.Greedy()
+    else:
+        explorer = explorers.LinearDecayEpsilonGreedy(
+        1.0, args.final_epsilon,
+        args.final_exploration_frames,
+        lambda: np.random.randint(n_actions))
 
     # Draw the computational graph and save it in the output directory.
     chainerrl.misc.draw_computational_graph(
@@ -201,11 +206,6 @@ def main():
             num_steps=args.num_step_return)
     else:
         rbuf = replay_buffer.ReplayBuffer(10 ** 6, args.num_step_return)
-
-    explorer = explorers.LinearDecayEpsilonGreedy(
-        1.0, args.final_epsilon,
-        args.final_exploration_frames,
-        lambda: np.random.randint(n_actions))
 
     def phi(x):
         # Feature extractor


### PR DESCRIPTION
Ran the following two commands on the new program:

- `python3 examples/ale/train_dqn_ale.py --gpu -1 --eval-interval 50 --steps 175 --replay-start-size 30 --eval-n-runs 1`

- `python3 examples/ale/train_dqn_ale.py --gpu -1 --eval-interval 50 --steps 175 --replay-start-size 35 --eval-n-runs 1 --noisy-net-sigma 0.2`

Both programs ran to completion.