### PR TITLE
Fixes minor grammar mistake in A3C ALE example

### DIFF
--- a/examples/ale/train_a3c_ale.py
+++ b/examples/ale/train_a3c_ale.py
@@ -100,8 +100,9 @@ def main():
     logging.basicConfig(level=args.logging_level)
 
     # Set a random seed used in ChainerRL.
-    # If you use more than one processes, the results will be no longer
-    # deterministic even with the same random seed.
+    # If you use more than one process (i.e. processes > 1),
+    # the results will be no longer be deterministic
+    # even with the same random seed.
     misc.set_random_seed(args.seed)
 
     # Set different random seeds for different subprocesses.


### PR DESCRIPTION
In the comment in the code, `processes` shouldn't be plural.