### PR TITLE
Link to chainer/chainer, not pfnet/chainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Documentation Status](https://readthedocs.org/projects/chainerrl/badge/?version=latest)](http://chainerrl.readthedocs.io/en/latest/?badge=latest)
 [![PyPI](https://img.shields.io/pypi/v/chainerrl.svg)](https://pypi.python.org/pypi/chainerrl)
 
-ChainerRL is a deep reinforcement learning library that implements various state-of-the-art deep reinforcement algorithms in Python using [Chainer](https://github.com/pfnet/chainer), a flexible deep learning framework.
+ChainerRL is a deep reinforcement learning library that implements various state-of-the-art deep reinforcement algorithms in Python using [Chainer](https://github.com/chainer/chainer), a flexible deep learning framework.
 
 ![Breakout](assets/breakout.gif)
 ![Humanoid](assets/humanoid.gif)


### PR DESCRIPTION
Although pfnet/chainer still works, chainer/chainer is correct now.