### PR TITLE
Pass env_id to replay buffer methods to correctly support batch training

### DIFF
--- a/chainerrl/agents/ddpg.py
+++ b/chainerrl/agents/ddpg.py
@@ -424,7 +424,7 @@ class DDPG(AttributeSavingMixin, BatchAgent):
                 )
                 if batch_reset[i] or batch_done[i]:
                     self.batch_last_obs[i] = None
-                    self.stop_current_episode(env_id=i)
+                    self.replay_buffer.stop_current_episode(env_id=i)
             self.replay_updater.update_if_necessary(self.t)
 
     def batch_observe(self, batch_obs, batch_reward,

--- a/chainerrl/agents/ddpg.py
+++ b/chainerrl/agents/ddpg.py
@@ -420,9 +420,11 @@ class DDPG(AttributeSavingMixin, BatchAgent):
                     next_state=batch_obs[i],
                     next_action=None,
                     is_state_terminal=batch_done[i],
+                    env_id=i,
                 )
                 if batch_reset[i] or batch_done[i]:
                     self.batch_last_obs[i] = None
+                    self.stop_current_episode(env_id=i)
             self.replay_updater.update_if_necessary(self.t)
 
     def batch_observe(self, batch_obs, batch_reward,

--- a/chainerrl/agents/dqn.py
+++ b/chainerrl/agents/dqn.py
@@ -470,9 +470,11 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
                     next_state=batch_obs[i],
                     next_action=None,
                     is_state_terminal=batch_done[i],
+                    env_id=i,
                 )
                 if batch_reset[i] or batch_done[i]:
                     self.batch_last_obs[i] = None
+                    self.replay_buffer.stop_current_episode(env_id=i)
             self.replay_updater.update_if_necessary(self.t)
 
     def batch_observe(self, batch_obs, batch_reward,

--- a/chainerrl/replay_buffer.py
+++ b/chainerrl/replay_buffer.py
@@ -156,7 +156,7 @@ class ReplayBuffer(AbstractReplayBuffer):
             next_state=next_state,
             next_action=next_action,
             is_state_terminal=is_state_terminal,
-            **kwargs,
+            **kwargs
         )
         last_n_transitions.append(experience)
         if is_state_terminal:

--- a/chainerrl/replay_buffer.py
+++ b/chainerrl/replay_buffer.py
@@ -29,7 +29,7 @@ class AbstractReplayBuffer(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def append(self, state, action, reward, next_state=None, next_action=None,
-               is_state_terminal=False):
+               is_state_terminal=False, env_id=0, **kwargs):
         """Append a transition to this replay buffer.
 
         Args:
@@ -39,6 +39,9 @@ class AbstractReplayBuffer(with_metaclass(ABCMeta, object)):
             next_state: s_{t+1} (can be None if terminal)
             next_action: a_{t+1} (can be None for off-policy algorithms)
             is_state_terminal (bool)
+            env_id (object): Object that is unique to each env. It indicates
+                which env a given transition came from in multi-env training.
+            **kwargs: Any other information to store.
         """
         raise NotImplementedError
 
@@ -113,7 +116,7 @@ class AbstractEpisodicReplayBuffer(AbstractReplayBuffer):
         raise NotImplementedError
 
     @abstractmethod
-    def stop_current_episode(self):
+    def stop_current_episode(self, env_id=0):
         """Notify the buffer that the current episode is interrupted.
 
         You may want to interrupt the current episode and start a new one
@@ -124,6 +127,11 @@ class AbstractEpisodicReplayBuffer(AbstractReplayBuffer):
 
         This method should not be called after an episode whose termination is
         already notified by appending a transition with is_state_terminal=True.
+
+        Args:
+            env_id (object): Object that is unique to each env. It indicates
+                which env's current episode is interrupted in multi-env
+                training.
         """
         raise NotImplementedError
 
@@ -135,35 +143,44 @@ class ReplayBuffer(AbstractReplayBuffer):
         assert num_steps > 0
         self.num_steps = num_steps
         self.memory = RandomAccessQueue(maxlen=capacity)
-        self.last_n_transitions = collections.deque([], maxlen=num_steps)
+        self.last_n_transitions = collections.defaultdict(
+            lambda: collections.deque([], maxlen=num_steps))
 
     def append(self, state, action, reward, next_state=None, next_action=None,
-               is_state_terminal=False):
-        experience = dict(state=state, action=action, reward=reward,
-                          next_state=next_state, next_action=next_action,
-                          is_state_terminal=is_state_terminal)
-        self.last_n_transitions.append(experience)
+               is_state_terminal=False, env_id=0, **kwargs):
+        last_n_transitions = self.last_n_transitions[env_id]
+        experience = dict(
+            state=state,
+            action=action,
+            reward=reward,
+            next_state=next_state,
+            next_action=next_action,
+            is_state_terminal=is_state_terminal,
+            **kwargs,
+        )
+        last_n_transitions.append(experience)
         if is_state_terminal:
-            while self.last_n_transitions:
-                self.memory.append(list(self.last_n_transitions))
-                del self.last_n_transitions[0]
-            assert len(self.last_n_transitions) == 0
+            while last_n_transitions:
+                self.memory.append(list(last_n_transitions))
+                del last_n_transitions[0]
+            assert len(last_n_transitions) == 0
         else:
-            if len(self.last_n_transitions) == self.num_steps:
-                self.memory.append(list(self.last_n_transitions))
+            if len(last_n_transitions) == self.num_steps:
+                self.memory.append(list(last_n_transitions))
 
-    def stop_current_episode(self):
+    def stop_current_episode(self, env_id=0):
+        last_n_transitions = self.last_n_transitions[env_id]
         # if n-step transition hist is not full, add transition;
         # if n-step hist is indeed full, transition has already been added;
-        if 0 < len(self.last_n_transitions) < self.num_steps:
-            self.memory.append(list(self.last_n_transitions))
+        if 0 < len(last_n_transitions) < self.num_steps:
+            self.memory.append(list(last_n_transitions))
         # avoid duplicate entry
-        if 0 < len(self.last_n_transitions) <= self.num_steps:
-            del self.last_n_transitions[0]
-        while self.last_n_transitions:
-            self.memory.append(list(self.last_n_transitions))
-            del self.last_n_transitions[0]
-        assert len(self.last_n_transitions) == 0
+        if 0 < len(last_n_transitions) <= self.num_steps:
+            del last_n_transitions[0]
+        while last_n_transitions:
+            self.memory.append(list(last_n_transitions))
+            del last_n_transitions[0]
+        assert len(last_n_transitions) == 0
 
     def sample(self, num_experiences):
         assert len(self.memory) >= num_experiences
@@ -267,7 +284,8 @@ class PrioritizedReplayBuffer(ReplayBuffer, PriorityWeightError):
         assert num_steps > 0
         self.num_steps = num_steps
         self.memory = PrioritizedBuffer(capacity=capacity)
-        self.last_n_transitions = collections.deque([], maxlen=num_steps)
+        self.last_n_transitions = collections.defaultdict(
+            lambda: collections.deque([], maxlen=num_steps))
         PriorityWeightError.__init__(
             self, alpha, beta0, betasteps, eps, normalize_by_max,
             error_min=error_min, error_max=error_max)
@@ -295,20 +313,21 @@ def random_subseq(seq, subseq_len):
 class EpisodicReplayBuffer(AbstractEpisodicReplayBuffer):
 
     def __init__(self, capacity=None):
-        self.current_episode = []
+        self.current_episode = collections.defaultdict(list)
         self.episodic_memory = RandomAccessQueue()
         self.memory = RandomAccessQueue()
         self.capacity = capacity
 
     def append(self, state, action, reward, next_state=None, next_action=None,
-               is_state_terminal=False, **kwargs):
+               is_state_terminal=False, env_id=0, **kwargs):
+        current_episode = self.current_episode[env_id]
         experience = dict(state=state, action=action, reward=reward,
                           next_state=next_state, next_action=next_action,
                           is_state_terminal=is_state_terminal,
                           **kwargs)
-        self.current_episode.append(experience)
+        current_episode.append(experience)
         if is_state_terminal:
-            self.stop_current_episode()
+            self.stop_current_episode(env_id=env_id)
 
     def sample(self, n):
         assert len(self.memory) >= n
@@ -353,17 +372,18 @@ class EpisodicReplayBuffer(AbstractEpisodicReplayBuffer):
                     self.episodic_memory.append(episode)
                     episode = []
 
-    def stop_current_episode(self):
-        if self.current_episode:
-            self.episodic_memory.append(self.current_episode)
-            self.memory.extend(self.current_episode)
-            self.current_episode = []
+    def stop_current_episode(self, env_id=0):
+        current_episode = self.current_episode[env_id]
+        if current_episode:
+            self.episodic_memory.append(current_episode)
+            self.memory.extend(current_episode)
+            self.current_episode[env_id] = []
             while self.capacity is not None and \
                     len(self.memory) > self.capacity:
                 discarded_episode = self.episodic_memory.popleft()
                 for _ in range(len(discarded_episode)):
                     self.memory.popleft()
-        assert not self.current_episode
+        assert not self.current_episode[env_id]
 
 
 class PrioritizedEpisodicReplayBuffer (
@@ -379,7 +399,7 @@ class PrioritizedEpisodicReplayBuffer (
                  error_min=None,
                  error_max=None,
                  ):
-        self.current_episode = []
+        self.current_episode = collections.defaultdict(list)
         self.episodic_memory = PrioritizedBuffer(
             capacity=None,
             wait_priority_after_sampling=wait_priority_after_sampling)
@@ -409,22 +429,22 @@ class PrioritizedEpisodicReplayBuffer (
         self.episodic_memory.set_last_priority(
             self.priority_from_errors(errors))
 
-    def stop_current_episode(self):
-        if self.current_episode:
+    def stop_current_episode(self, env_id=0):
+        current_episode = self.current_episode[env_id]
+        if current_episode:
             if self.default_priority_func is not None:
-                priority = self.default_priority_func(self.current_episode)
+                priority = self.default_priority_func(current_episode)
             else:
                 priority = None
-            self.memory.extend(self.current_episode)
-            self.episodic_memory.append(self.current_episode,
-                                        priority=priority)
+            self.memory.extend(current_episode)
+            self.episodic_memory.append(current_episode, priority=priority)
             if self.capacity_left is not None:
-                self.capacity_left -= len(self.current_episode)
-            self.current_episode = []
+                self.capacity_left -= len(current_episode)
+            self.current_episode[env_id] = []
             while self.capacity_left is not None and self.capacity_left < 0:
                 discarded_episode = self.episodic_memory.popleft()
                 self.capacity_left += len(discarded_episode)
-        assert not self.current_episode
+        assert not self.current_episode[env_id]
 
 
 def batch_experiences(experiences, xp, phi, gamma, batch_states=batch_states):

--- a/examples/ale/train_dqn_batch_ale.py
+++ b/examples/ale/train_dqn_batch_ale.py
@@ -120,6 +120,7 @@ def main():
     parser.add_argument('--prioritized', action='store_true', default=False,
                         help='Use prioritized experience replay.')
     parser.add_argument('--num-envs', type=int, default=1)
+    parser.add_argument('--n-step-return', type=int, default=1)
     args = parser.parse_args()
 
     import logging
@@ -192,9 +193,12 @@ def main():
         # Anneal beta from beta0 to 1 throughout training
         betasteps = args.steps / args.update_interval
         rbuf = replay_buffer.PrioritizedReplayBuffer(
-            10 ** 6, alpha=0.6, beta0=0.4, betasteps=betasteps)
+            10 ** 6, alpha=0.6, beta0=0.4, betasteps=betasteps,
+            num_steps=args.n_step_return,
+        )
     else:
-        rbuf = replay_buffer.ReplayBuffer(10 ** 6)
+        rbuf = replay_buffer.ReplayBuffer(
+            10 ** 6, num_steps=args.n_step_return)
 
     explorer = explorers.LinearDecayEpsilonGreedy(
         1.0, args.final_epsilon,

--- a/tests/test_replay_buffer.py
+++ b/tests/test_replay_buffer.py
@@ -506,17 +506,17 @@ class TestReplayBufferWithEnvID(unittest.TestCase):
         for i in range(2):
             trans1 = dict(state=0, action=1, reward=2, next_state=3,
                           next_action=4, is_state_terminal=False)
-            rbuf.append(**trans1, env_id=0)
+            rbuf.append(env_id=0, **trans1)
         # 4 transitions for env_id=1 with a terminal state
         for i in range(4):
             trans1 = dict(state=0, action=1, reward=2, next_state=3,
                           next_action=4, is_state_terminal=(i == 3))
-            rbuf.append(**trans1, env_id=1)
+            rbuf.append(env_id=1, **trans1)
         # 9 transitions for env_id=2
         for i in range(9):
             trans1 = dict(state=0, action=1, reward=2, next_state=3,
                           next_action=4, is_state_terminal=False)
-            rbuf.append(**trans1, env_id=2)
+            rbuf.append(env_id=2, **trans1)
 
         # It should have:
         #   - 4 transitions from env_id=1
@@ -554,17 +554,17 @@ class TestEpisodicReplayBufferWithEnvID(unittest.TestCase):
         for i in range(2):
             trans1 = dict(state=0, action=1, reward=2, next_state=3,
                           next_action=4, is_state_terminal=False)
-            rbuf.append(**trans1, env_id=0)
+            rbuf.append(env_id=0, **trans1)
         # 4 transitions for env_id=1 with a terminal state
         for i in range(4):
             trans1 = dict(state=0, action=1, reward=2, next_state=3,
                           next_action=4, is_state_terminal=(i == 3))
-            rbuf.append(**trans1, env_id=1)
+            rbuf.append(env_id=1, **trans1)
         # 9 transitions for env_id=2
         for i in range(9):
             trans1 = dict(state=0, action=1, reward=2, next_state=3,
                           next_action=4, is_state_terminal=False)
-            rbuf.append(**trans1, env_id=2)
+            rbuf.append(env_id=2, **trans1)
 
         # It should have 4 transitions from env_id=1
         self.assertEqual(len(rbuf), 4)


### PR DESCRIPTION
~Merge #443 before this PR.~

Current replay buffers with num_steps > 1 or episodic are not correct in batch training because they cannot know which env a given transition came from.

This PR adds the `env_id` argument to two methods of replay buffers: `append` and `stop_current_episode`. From `env_id` replay buffers can know which env a given transition came from and which env's episode is stopped.

TODO:
- [x] check how it affects scores with n-step return and batch training