### PR TITLE
Add VectorStackFrame to reduce memory usage in train_dqn_batch_ale.py

### DIFF
--- a/chainerrl/env.py
+++ b/chainerrl/env.py
@@ -53,3 +53,12 @@ class VectorEnv(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def close(self):
         raise NotImplementedError()
+
+    @property
+    def unwrapped(self):
+        """Completely unwrap this env.
+
+        Returns:
+            VectorEnv: The base non-wrapped VectorEnv instance
+        """
+        return self

--- a/chainerrl/wrappers/__init__.py
+++ b/chainerrl/wrappers/__init__.py
@@ -8,3 +8,5 @@ from chainerrl.wrappers.randomize_action import RandomizeAction  # NOQA
 from chainerrl.wrappers.render import Render  # NOQA
 
 from chainerrl.wrappers.scale_reward import ScaleReward  # NOQA
+
+from chainerrl.wrappers.vector_frame_stack import VectorFrameStack  # NOQA

--- a/chainerrl/wrappers/vector_frame_stack.py
+++ b/chainerrl/wrappers/vector_frame_stack.py
@@ -78,11 +78,12 @@ class VectorFrameStack(VectorEnvWrapper):
         self.k = k
         self.stack_axis = stack_axis
         self.frames = [deque([], maxlen=k) for _ in range(env.num_envs)]
-        orig_shape = env.observation_space.shape
-        shape = list(orig_shape)
-        shape[self.stack_axis] *= k
+        orig_obs_space = env.observation_space
+        assert isinstance(orig_obs_space, spaces.Box)
+        low = np.repeat(orig_obs_space.low, k, axis=self.stack_axis)
+        high = np.repeat(orig_obs_space.high, k, axis=self.stack_axis)
         self.observation_space = spaces.Box(
-            low=0, high=255, shape=shape, dtype=np.uint8)
+            low=low, high=high, dtype=orig_obs_space.dtype)
 
     def reset(self, mask=None):
         batch_ob = self.env.reset(mask=mask)

--- a/chainerrl/wrappers/vector_frame_stack.py
+++ b/chainerrl/wrappers/vector_frame_stack.py
@@ -1,0 +1,107 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()  # NOQA
+
+from collections import deque
+
+from gym import spaces
+import numpy as np
+
+from chainerrl.wrappers.atari_wrappers import LazyFrames
+from chainerrl.env import VectorEnv
+
+
+class VectorEnvWrapper(VectorEnv):
+    """VectorEnv analog to gym.Wrapper."""
+
+    def __init__(self, env):
+        self.env = env
+        self.action_space = self.env.action_space
+        self.observation_space = self.env.observation_space
+
+    def __getattr__(self, name):
+        if name.startswith('_'):
+            raise AttributeError(
+                "attempted to get missing private attribute '{}'".format(name))
+        return getattr(self.env, name)
+
+    def step(self, action):
+        return self.env.step(action)
+
+    def reset(self, **kwargs):
+        return self.env.reset(**kwargs)
+
+    def render(self, mode='human', **kwargs):
+        return self.env.render(mode, **kwargs)
+
+    def close(self):
+        return self.env.close()
+
+    def seed(self, seed=None):
+        return self.env.seed(seed)
+
+    def compute_reward(self, achieved_goal, desired_goal, info):
+        return self.env.compute_reward(achieved_goal, desired_goal, info)
+
+    def __str__(self):
+        return '<{}{}>'.format(type(self).__name__, self.env)
+
+    def __repr__(self):
+        return str(self)
+
+    @property
+    def unwrapped(self):
+        return self.env.unwrapped
+
+
+class VectorFrameStack(VectorEnvWrapper):
+    """VectorEnv analog to chainerrl.wrappers.atari_wrappers.FrameStack.
+
+    The original `chainerrl.wrappers.atari_wrappers.FrameStack` does not work
+    properly with `chainerrl.envs.MultiprocessVectorEnv` because LazyFrames
+    becomes not lazy when passed between processes, unnecessarily increasing
+    memory usage. To avoid the issue, use this wrapper instead of `FrameStack`
+    so that LazyFrames are not passed between processes.
+
+    Args:
+        env (VectorEnv): Env to wrap.
+        k (int): How many frames to stack.
+        stack_axis (int): Axis along which frames are concatenated.
+    """
+
+    def __init__(self, env, k, stack_axis=0):
+        """Stack k last frames."""
+        VectorEnvWrapper.__init__(self, env)
+        self.k = k
+        self.stack_axis = stack_axis
+        self.frames = [deque([], maxlen=k) for _ in range(env.num_envs)]
+        orig_shape = env.observation_space.shape
+        shape = list(orig_shape)
+        shape[self.stack_axis] *= k
+        self.observation_space = spaces.Box(
+            low=0, high=255, shape=shape, dtype=np.uint8)
+
+    def reset(self, mask=None):
+        batch_ob = self.env.reset(mask=mask)
+        if mask is None:
+            mask = np.zeros(self.env.num_envs)
+        for m, frames, ob in zip(mask, self.frames, batch_ob):
+            if not m:
+                for _ in range(self.k):
+                    frames.append(ob)
+        return self._get_ob()
+
+    def step(self, action):
+        batch_ob, reward, done, info = self.env.step(action)
+        for frames, ob in zip(self.frames, batch_ob):
+            frames.append(ob)
+        return self._get_ob(), reward, done, info
+
+    def _get_ob(self):
+        assert len(self.frames) == self.env.num_envs
+        assert len(self.frames[0]) == self.k
+        return [LazyFrames(list(frames), stack_axis=self.stack_axis)
+                for frames in self.frames]

--- a/examples/ale/train_dqn_batch_ale.py
+++ b/examples/ale/train_dqn_batch_ale.py
@@ -144,7 +144,9 @@ def main():
         env = atari_wrappers.wrap_deepmind(
             atari_wrappers.make_atari(args.env, max_frames=args.max_frames),
             episode_life=not test,
-            clip_rewards=not test)
+            clip_rewards=not test,
+            frame_stack=False,
+        )
         if test:
             # Randomize actions like epsilon-greedy in evaluation as well
             env = chainerrl.wrappers.RandomizeAction(env, args.eval_epsilon)
@@ -158,9 +160,11 @@ def main():
         return env
 
     def make_batch_env(test):
-        return chainerrl.envs.MultiprocessVectorEnv(
+        vec_env = chainerrl.envs.MultiprocessVectorEnv(
             [(lambda: make_env(idx, test))
              for idx, env in enumerate(range(args.num_envs))])
+        vec_env = chainerrl.wrappers.VectorFrameStack(vec_env, 4)
+        return vec_env
 
     sample_env = make_env(0, test=False)
 

--- a/tests/wrappers_tests/test_vector_frame_stack.py
+++ b/tests/wrappers_tests/test_vector_frame_stack.py
@@ -17,7 +17,24 @@ import numpy as np
 import chainerrl
 from chainerrl.wrappers.atari_wrappers import FrameStack
 from chainerrl.wrappers.atari_wrappers import LazyFrames
+from chainerrl.wrappers.vector_frame_stack import VectorEnvWrapper
 from chainerrl.wrappers.vector_frame_stack import VectorFrameStack
+
+
+class TestVectorEnvWrapper(unittest.TestCase):
+
+    def test(self):
+
+        vec_env = chainerrl.envs.SerialVectorEnv(
+            [mock.Mock() for _ in range(3)])
+
+        wrapped_vec_env = VectorEnvWrapper(vec_env)
+
+        self.assertIs(wrapped_vec_env.env, vec_env)
+        self.assertIs(wrapped_vec_env.unwrapped, vec_env.unwrapped)
+        self.assertIs(wrapped_vec_env.action_space, vec_env.action_space)
+        self.assertIs(
+            wrapped_vec_env.observation_space, vec_env.observation_space)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/wrappers_tests/test_vector_frame_stack.py
+++ b/tests/wrappers_tests/test_vector_frame_stack.py
@@ -63,7 +63,7 @@ class TestVectorFrameStack(unittest.TestCase):
                 for _ in range(steps)]
             env.action_space = gym.spaces.Discrete(2)
             env.observation_space = gym.spaces.Box(
-                low=0, high=1, shape=(1, 84, 84), dtype=np.uint8)
+                low=0, high=255, shape=(1, 84, 84), dtype=np.uint8)
             return env
 
         # Wrap by FrameStack and MultiprocessVectorEnv
@@ -78,6 +78,9 @@ class TestVectorFrameStack(unittest.TestCase):
                 [(lambda: make_env(idx))
                  for idx, env in enumerate(range(self.num_envs))]),
             k=self.k, stack_axis=0)
+
+        self.assertEqual(fs_env.action_space, vfs_env.action_space)
+        self.assertEqual(fs_env.observation_space, vfs_env.observation_space)
 
         fs_obs = fs_env.reset()
         vfs_obs = vfs_env.reset()

--- a/tests/wrappers_tests/test_vector_frame_stack.py
+++ b/tests/wrappers_tests/test_vector_frame_stack.py
@@ -1,0 +1,110 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()  # NOQA
+
+import mock
+import unittest
+
+from chainer import testing
+import gym
+import gym.spaces
+import numpy as np
+
+import chainerrl
+from chainerrl.wrappers.atari_wrappers import FrameStack
+from chainerrl.wrappers.atari_wrappers import LazyFrames
+from chainerrl.wrappers.vector_frame_stack import VectorFrameStack
+
+
+@testing.parameterize(*testing.product({
+    'num_envs': [1, 3],
+    'k': [2, 3],
+}))
+class TestVectorFrameStack(unittest.TestCase):
+
+    def test(self):
+
+        steps = 10
+
+        # Mock env that returns atari-like frames
+        def make_env(idx):
+            env = mock.Mock()
+            np_random = np.random.RandomState(idx)
+            env.reset.side_effect = [
+                np_random.rand(1, 84, 84) for _ in range(steps)]
+            env.step.side_effect = [
+                (
+                    np_random.rand(1, 84, 84),
+                    np_random.rand(),
+                    bool(np_random.randint(2)),
+                    {},
+                )
+                for _ in range(steps)]
+            env.action_space = gym.spaces.Discrete(2)
+            env.observation_space = gym.spaces.Box(
+                low=0, high=1, shape=(1, 84, 84), dtype=np.uint8)
+            return env
+
+        # Wrap by FrameStack and MultiprocessVectorEnv
+        fs_env = chainerrl.envs.MultiprocessVectorEnv(
+            [(lambda: FrameStack(
+                make_env(idx), k=self.k, channel_order='chw'))
+             for idx, env in enumerate(range(self.num_envs))])
+
+        # Wrap by MultiprocessVectorEnv and VectorFrameStack
+        vfs_env = VectorFrameStack(
+            chainerrl.envs.MultiprocessVectorEnv(
+                [(lambda: make_env(idx))
+                 for idx, env in enumerate(range(self.num_envs))]),
+            k=self.k, stack_axis=0)
+
+        fs_obs = fs_env.reset()
+        vfs_obs = vfs_env.reset()
+
+        # Same LazyFrames observations
+        for env_idx in range(self.num_envs):
+            self.assertIsInstance(fs_obs[env_idx], LazyFrames)
+            self.assertIsInstance(vfs_obs[env_idx], LazyFrames)
+            np.testing.assert_allclose(
+                np.asarray(fs_obs[env_idx]), np.asarray(vfs_obs[env_idx]))
+
+        batch_action = [0] * self.num_envs
+        fs_new_obs, fs_r, fs_done, _ = fs_env.step(batch_action)
+        vfs_new_obs, vfs_r, vfs_done, _ = vfs_env.step(batch_action)
+
+        # Same LazyFrames observations, but those from fs_env are copies
+        # while those from vfs_env are references.
+        for env_idx in range(self.num_envs):
+            self.assertIsInstance(fs_new_obs[env_idx], LazyFrames)
+            self.assertIsInstance(vfs_new_obs[env_idx], LazyFrames)
+            np.testing.assert_allclose(
+                np.asarray(fs_new_obs[env_idx]),
+                np.asarray(vfs_new_obs[env_idx]))
+            self.assertIsNot(
+                fs_new_obs[env_idx]._frames[-2],
+                fs_obs[env_idx]._frames[-1])
+            self.assertIs(
+                vfs_new_obs[env_idx]._frames[-2],
+                vfs_obs[env_idx]._frames[-1])
+
+        np.testing.assert_allclose(fs_r, vfs_r)
+        np.testing.assert_allclose(fs_done, vfs_done)
+
+        # Check equivalence
+        for _ in range(steps - 1):
+            fs_env.reset(mask=np.logical_not(fs_done))
+            vfs_env.reset(mask=np.logical_not(vfs_done))
+            fs_obs, fs_r, fs_done, _ = fs_env.step(batch_action)
+            vfs_obs, vfs_r, vfs_done, _ = vfs_env.step(batch_action)
+            for env_idx in range(self.num_envs):
+                self.assertIsInstance(fs_new_obs[env_idx], LazyFrames)
+                self.assertIsInstance(vfs_new_obs[env_idx], LazyFrames)
+                np.testing.assert_allclose(
+                    np.asarray(fs_new_obs[env_idx]),
+                    np.asarray(vfs_new_obs[env_idx]))
+            np.testing.assert_allclose(fs_r, vfs_r)
+            np.testing.assert_allclose(fs_done, vfs_done)


### PR DESCRIPTION
This PR adds

- `VectorEnvWrapper`: an VectorEnv analog to `gym.Wrapper`
- `VectorStackFrame`: an VectorEnv analog to `chainerrl.wrappers.atari_wrappers.StackFrame`

to reduce memory usage in `train_dqn_batch_ale.py`.

The current example wraps envs by `StackFrame` then by `MultiprocessVectorEnv`. This is actually memory inefficient because when `LazyFrames` is passed between processes via Pipe, it becomes not lazy anymore due to pickling. This PR solves the issue by stacking frames in the main process.

TODO:
- [x] add experimental results to validate this change