### PR TITLE
make FrameStack follow original spaces

### DIFF
--- a/chainerrl/wrappers/atari_wrappers.py
+++ b/chainerrl/wrappers/atari_wrappers.py
@@ -183,12 +183,12 @@ class FrameStack(gym.Wrapper):
         gym.Wrapper.__init__(self, env)
         self.k = k
         self.frames = deque([], maxlen=k)
-        orig_shape = env.observation_space.shape
         self.stack_axis = {'hwc': 2, 'chw': 0}[channel_order]
-        shape = list(orig_shape)
-        shape[self.stack_axis] *= k
+        orig_obs_space = env.observation_space
+        low = np.repeat(orig_obs_space.low, k, axis=self.stack_axis)
+        high = np.repeat(orig_obs_space.high, k, axis=self.stack_axis)
         self.observation_space = spaces.Box(
-            low=0, high=255, shape=shape, dtype=np.uint8)
+            low=low, high=high, dtype=orig_obs_space.dtype)
 
     def _reset(self):
         ob = self.env.reset()

--- a/tests/wrappers_tests/test_atari_wrappers.py
+++ b/tests/wrappers_tests/test_atari_wrappers.py
@@ -1,0 +1,95 @@
+"""Currently this script tests `chainerrl.wrappers.atari_wrappers.FrameStack`
+only."""
+
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()  # NOQA
+
+import mock
+import unittest
+
+from chainer import testing
+import gym
+import gym.spaces
+import numpy as np
+
+from chainerrl.wrappers.atari_wrappers import FrameStack, LazyFrames
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [np.uint8, np.float32],
+    'k': [2, 3],
+}))
+class TestFrameStack(unittest.TestCase):
+
+    def test_frame_stack(self):
+
+        steps = 10
+
+        # Mock env that returns atari-like frames
+        def make_env(idx):
+            env = mock.Mock()
+            np_random = np.random.RandomState(idx)
+            if self.dtype is np.uint8:
+                def dtyped_rand():
+                    return np_random.randint(
+                        low=0, high=255, size=(1, 84, 84), dtype=self.dtype)
+                low, high = 0, 255
+            elif self.dtype is np.float32:
+                def dtyped_rand():
+                    return np_random.rand(1, 84, 84).astype(self.dtype)
+                low, high = -1.0, 3.14
+            else:
+                assert False
+            env.reset.side_effect = [dtyped_rand() for _ in range(steps)]
+            env.step.side_effect = [
+                (
+                    dtyped_rand(),
+                    np_random.rand(),
+                    bool(np_random.randint(2)),
+                    {},
+                )
+                for _ in range(steps)]
+            env.action_space = gym.spaces.Discrete(2)
+            env.observation_space = gym.spaces.Box(
+                low=low, high=high, shape=(1, 84, 84), dtype=self.dtype)
+            return env
+
+        env = make_env(42)
+        fs_env = FrameStack(make_env(42), k=self.k, channel_order='chw')
+
+        # check action/observation space
+        self.assertEqual(env.action_space, fs_env.action_space)
+        self.assertIs(
+            env.observation_space.dtype, fs_env.observation_space.dtype)
+        self.assertEqual(
+            env.observation_space.low.item(0),
+            fs_env.observation_space.low.item(0))
+        self.assertEqual(
+            env.observation_space.high.item(0),
+            fs_env.observation_space.high.item(0))
+
+        # check reset
+        obs = env.reset()
+        fs_obs = fs_env.reset()
+        self.assertIsInstance(fs_obs, LazyFrames)
+        np.testing.assert_allclose(
+            obs.take(indices=0, axis=fs_env.stack_axis),
+            np.asarray(fs_obs).take(indices=0, axis=fs_env.stack_axis))
+
+        # check step
+        for _ in range(steps - 1):
+            action = env.action_space.sample()
+            fs_action = fs_env.action_space.sample()
+            obs, r, done, info = env.step(action)
+            fs_obs, fs_r, fs_done, fs_info = fs_env.step(fs_action)
+            self.assertIsInstance(fs_obs, LazyFrames)
+            np.testing.assert_allclose(
+                obs.take(indices=0, axis=fs_env.stack_axis),
+                np.asarray(fs_obs).take(indices=-1, axis=fs_env.stack_axis))
+            self.assertEqual(r, fs_r)
+            self.assertEqual(done, fs_done)


### PR DESCRIPTION
This PR makes `chainerrl.wrappers.atari_wrappers.FrameStack` follow `low`, `high` and `dtype` of  wrapping env's observation space.
Also some tests for `chainerrl.wrappers.atari_wrappers.FrameStack` are added, but tests for other classes defined in `chainerrl.wrappers.atari_wrappers` are still missing.

See also: #443 