### PR TITLE
Fix a bug of unintentionally using same process indices

### DIFF
--- a/examples/ale/train_a2c_ale.py
+++ b/examples/ale/train_a2c_ale.py
@@ -7,6 +7,7 @@ from future import standard_library
 standard_library.install_aliases()  # NOQA
 
 import argparse
+import functools
 import logging
 
 import chainer
@@ -123,7 +124,7 @@ def main():
 
     def make_batch_env(test):
         return chainerrl.envs.MultiprocessVectorEnv(
-            [(lambda: make_env(idx, test))
+            [functools.partial(make_env, idx, test)
              for idx, env in enumerate(range(args.num_envs))])
 
     sample_env = make_env(0, test=False)

--- a/examples/ale/train_dqn_batch_ale.py
+++ b/examples/ale/train_dqn_batch_ale.py
@@ -6,6 +6,7 @@ from builtins import *  # NOQA
 from future import standard_library
 standard_library.install_aliases()  # NOQA
 import argparse
+import functools
 import os
 
 import chainer
@@ -161,7 +162,7 @@ def main():
 
     def make_batch_env(test):
         vec_env = chainerrl.envs.MultiprocessVectorEnv(
-            [(lambda: make_env(idx, test))
+            [functools.partial(make_env, idx, test)
              for idx, env in enumerate(range(args.num_envs))])
         vec_env = chainerrl.wrappers.VectorFrameStack(vec_env, 4)
         return vec_env

--- a/examples/gym/train_a2c_gym.py
+++ b/examples/gym/train_a2c_gym.py
@@ -14,6 +14,7 @@ from builtins import *  # NOQA
 from future import standard_library
 standard_library.install_aliases()  # NOQA
 import argparse
+import functools
 
 import chainer
 from chainer import functions as F
@@ -153,7 +154,7 @@ def main():
 
     def make_batch_env(test):
         return chainerrl.envs.MultiprocessVectorEnv(
-            [(lambda: make_env(idx, test))
+            [functools.partial(make_env, idx, test)
              for idx, env in enumerate(range(args.num_envs))])
 
     sample_env = make_env(process_idx=0, test=False)

--- a/examples/gym/train_ddpg_batch_gym.py
+++ b/examples/gym/train_ddpg_batch_gym.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()  # NOQA
 import argparse
+import functools
 import sys
 
 import chainer
@@ -106,7 +107,7 @@ def main():
 
     def make_batch_env(test):
         return chainerrl.envs.MultiprocessVectorEnv(
-            [(lambda: make_env(idx, test))
+            [functools.partial(make_env, idx, test)
              for idx, env in enumerate(range(args.num_envs))])
 
     sample_env = make_env(0, test=False)

--- a/examples/gym/train_ppo_batch_gym.py
+++ b/examples/gym/train_ppo_batch_gym.py
@@ -14,6 +14,7 @@ from builtins import *  # NOQA
 from future import standard_library
 standard_library.install_aliases()  # NOQA
 import argparse
+import functools
 
 import chainer
 from chainer import functions as F
@@ -96,7 +97,7 @@ def main():
 
     def make_batch_env(test):
         return chainerrl.envs.MultiprocessVectorEnv(
-            [(lambda: make_env(idx, test))
+            [functools.partial(make_env, idx, test)
              for idx, env in enumerate(range(args.num_envs))])
 
     # Only for getting timesteps, and obs-action spaces

--- a/tests/wrappers_tests/test_vector_frame_stack.py
+++ b/tests/wrappers_tests/test_vector_frame_stack.py
@@ -6,6 +6,7 @@ from builtins import *  # NOQA
 from future import standard_library
 standard_library.install_aliases()  # NOQA
 
+import functools
 import mock
 import unittest
 
@@ -68,14 +69,14 @@ class TestVectorFrameStack(unittest.TestCase):
 
         # Wrap by FrameStack and MultiprocessVectorEnv
         fs_env = chainerrl.envs.MultiprocessVectorEnv(
-            [(lambda: FrameStack(
-                make_env(idx), k=self.k, channel_order='chw'))
+            [functools.partial(
+                FrameStack, make_env(idx), k=self.k, channel_order='chw')
              for idx, env in enumerate(range(self.num_envs))])
 
         # Wrap by MultiprocessVectorEnv and VectorFrameStack
         vfs_env = VectorFrameStack(
             chainerrl.envs.MultiprocessVectorEnv(
-                [(lambda: make_env(idx))
+                [functools.partial(make_env, idx)
                  for idx, env in enumerate(range(self.num_envs))]),
             k=self.k, stack_axis=0)
 


### PR DESCRIPTION
I noticed some of batch training examples have a bug that unintentionally uses same process indices (thus same random seeds!) across env processes. This PR fixes the bug.

You can see the current and new behaviors by running the code below. 
```
import functools
import chainerrl
import gym

num_envs = 4


def make_env(process_idx, test):
    print(process_idx, test)
    return gym.make('Pendulum-v0')


def make_batch_env_old(test):
    return chainerrl.envs.MultiprocessVectorEnv(
        [(lambda: make_env(idx, test))
         for idx, env in enumerate(range(num_envs))])


def make_batch_env_new(test):
    return chainerrl.envs.MultiprocessVectorEnv(
        [functools.partial(make_env, idx, test)
         for idx, env in enumerate(range(num_envs))])


print('make_batch_env_old')
make_batch_env_old(test=False)
make_batch_env_old(test=True)

print('make_batch_env_new')
make_batch_env_new(test=False)
make_batch_env_new(test=True)
```

This code will outputs:
```
make_batch_env_old
3 False
3 False
3 False
3 False
3 True
3 True
3 True
3 True
make_batch_env_new
0 False
1 False
2 False
3 False
0 True
1 True
2 True
3 True
```

Even when same random seeds are used in env processes, actions sent by the agent are usually different due to  the stochasticity of policy or eplorer, so this may not result in noticeable difference in learning results, but this is definitely a bug that needs to be fixed.