### PR TITLE
fix ScaledFloatFrame.observation_space

### DIFF
--- a/chainerrl/wrappers/atari_wrappers.py
+++ b/chainerrl/wrappers/atari_wrappers.py
@@ -222,6 +222,7 @@ class ScaledFloatFrame(gym.ObservationWrapper):
     Especially, when the original env.observation_space is np.uint8,
     this wrapper converts frame values into [0.0, 1.0] of dtype np.float32.
     """
+
     def __init__(self, env):
         assert isinstance(env.observation_space, spaces.Box)
         gym.ObservationWrapper.__init__(self, env)

--- a/chainerrl/wrappers/atari_wrappers.py
+++ b/chainerrl/wrappers/atari_wrappers.py
@@ -217,13 +217,27 @@ class FrameStack(gym.Wrapper):
 
 
 class ScaledFloatFrame(gym.ObservationWrapper):
+    """Divide frame values by 255.0 and return them as np.float32.
+
+    Especially, when the original env.observation_space is np.uint8,
+    this wrapper converts frame values into [0.0, 1.0] of dtype np.float32.
+    """
     def __init__(self, env):
+        assert isinstance(env.observation_space, spaces.Box)
         gym.ObservationWrapper.__init__(self, env)
+
+        self.scale = 255.0
+
+        orig_obs_space = env.observation_space
+        self.observation_space = spaces.Box(
+            low=self._observation(orig_obs_space.low),
+            high=self._observation(orig_obs_space.high),
+            dtype=np.float32)
 
     def _observation(self, observation):
         # careful! This undoes the memory optimization, use
         # with smaller replay buffers only.
-        return np.array(observation).astype(np.float32) / 255.0
+        return np.array(observation).astype(np.float32) / self.scale
 
 
 class LazyFrames(object):

--- a/tests/wrappers_tests/test_atari_wrappers.py
+++ b/tests/wrappers_tests/test_atari_wrappers.py
@@ -17,7 +17,8 @@ import gym
 import gym.spaces
 import numpy as np
 
-from chainerrl.wrappers.atari_wrappers import FrameStack, LazyFrames, ScaledFloatFrame
+from chainerrl.wrappers.atari_wrappers import FrameStack, LazyFrames
+from chainerrl.wrappers.atari_wrappers import ScaledFloatFrame
 
 
 @testing.parameterize(*testing.product({
@@ -137,10 +138,13 @@ class TestScaledFloatFrame(unittest.TestCase):
         s_env = ScaledFloatFrame(make_env(42))
 
         # check observation space
-        self.assertIs(type(env.observation_space), type(s_env.observation_space))
+        self.assertIs(
+            type(env.observation_space), type(s_env.observation_space))
         self.assertIs(s_env.observation_space.dtype, np.dtype(np.float32))
-        self.assertTrue(s_env.observation_space.contains(s_env.observation_space.low))
-        self.assertTrue(s_env.observation_space.contains(s_env.observation_space.high))
+        self.assertTrue(
+            s_env.observation_space.contains(s_env.observation_space.low))
+        self.assertTrue(
+            s_env.observation_space.contains(s_env.observation_space.high))
 
         # check reset
         obs = env.reset()

--- a/tests/wrappers_tests/test_atari_wrappers.py
+++ b/tests/wrappers_tests/test_atari_wrappers.py
@@ -17,7 +17,7 @@ import gym
 import gym.spaces
 import numpy as np
 
-from chainerrl.wrappers.atari_wrappers import FrameStack, LazyFrames
+from chainerrl.wrappers.atari_wrappers import FrameStack, LazyFrames, ScaledFloatFrame
 
 
 @testing.parameterize(*testing.product({
@@ -93,3 +93,66 @@ class TestFrameStack(unittest.TestCase):
                 np.asarray(fs_obs).take(indices=-1, axis=fs_env.stack_axis))
             self.assertEqual(r, fs_r)
             self.assertEqual(done, fs_done)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [np.uint8, np.float32],
+}))
+class TestScaledFloatFrame(unittest.TestCase):
+
+    def test_scaled_float_frame(self):
+
+        steps = 10
+
+        # Mock env that returns atari-like frames
+        def make_env(idx):
+            env = mock.Mock()
+            np_random = np.random.RandomState(idx)
+            if self.dtype is np.uint8:
+                def dtyped_rand():
+                    return np_random.randint(
+                        low=0, high=255, size=(1, 84, 84), dtype=self.dtype)
+                low, high = 0, 255
+            elif self.dtype is np.float32:
+                def dtyped_rand():
+                    return np_random.rand(1, 84, 84).astype(self.dtype)
+                low, high = -1.0, 3.14
+            else:
+                assert False
+            env.reset.side_effect = [dtyped_rand() for _ in range(steps)]
+            env.step.side_effect = [
+                (
+                    dtyped_rand(),
+                    np_random.rand(),
+                    bool(np_random.randint(2)),
+                    {},
+                )
+                for _ in range(steps)]
+            env.action_space = gym.spaces.Discrete(2)
+            env.observation_space = gym.spaces.Box(
+                low=low, high=high, shape=(1, 84, 84), dtype=self.dtype)
+            return env
+
+        env = make_env(42)
+        s_env = ScaledFloatFrame(make_env(42))
+
+        # check observation space
+        self.assertIs(type(env.observation_space), type(s_env.observation_space))
+        self.assertIs(s_env.observation_space.dtype, np.dtype(np.float32))
+        self.assertTrue(s_env.observation_space.contains(s_env.observation_space.low))
+        self.assertTrue(s_env.observation_space.contains(s_env.observation_space.high))
+
+        # check reset
+        obs = env.reset()
+        s_obs = s_env.reset()
+        np.testing.assert_allclose(np.array(obs) / s_env.scale, s_obs)
+
+        # check step
+        for _ in range(steps - 1):
+            action = env.action_space.sample()
+            s_action = s_env.action_space.sample()
+            obs, r, done, info = env.step(action)
+            s_obs, s_r, s_done, s_info = s_env.step(s_action)
+            np.testing.assert_allclose(np.array(obs) / s_env.scale, s_obs)
+            self.assertEqual(r, s_r)
+            self.assertEqual(done, s_done)


### PR DESCRIPTION
`ScaledFloatFrame.observation_space` was not properly converted and it resulted in some inconsistency, such as `observation_space.low/high/sample/contains`.