### PR TITLE
update requirements.txt and setup.py for gym

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ chainer>=4.0.0
 fastcache; python_version<'3.2'
 funcsigs; python_version<'3.5'
 future
-gym>=0.9.7
+gym>=0.9.7,<=0.12.1
 numpy>=1.10.4
 pillow
 scipy

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
     'cached-property',
     'chainer>=2.0.0',
     'future',
-    'gym>=0.9.7',
+    'gym>=0.9.7,<=0.12.1',
     'numpy>=1.10.4',
     'pillow',
     'scipy',


### PR DESCRIPTION
The latest version of `gym` dropped support of underscore methods in env_wrappers like `_observation`.
ChainerRL now implements underscore methods, we need to fix the version of `gym`.

Here is my installation log (at a brand new virtualenv):
```
$ python setup.py install
*snip*

$ pip freeze
cached-property==1.5.1
certifi==2019.3.9
chainer==7.0.0a1
chainerrl==0.6.0
chardet==3.0.4
filelock==3.0.12
future==0.17.1
gym==0.12.1
idna==2.8
numpy==1.16.4
Pillow==6.0.0
protobuf==3.7.1
pyglet==1.4.0b1
requests==2.22.0
scipy==1.3.0
six==1.12.0
typing==3.6.6
typing-extensions==3.7.2
urllib3==1.25.3
```