### PR TITLE
Support `gym>=0.12.2` by stopping to use underscore methods in gym wrappers

### DIFF
--- a/chainerrl/wrappers/atari_wrappers.py
+++ b/chainerrl/wrappers/atari_wrappers.py
@@ -32,7 +32,7 @@ class NoopResetEnv(gym.Wrapper):
         self.noop_action = 0
         assert env.unwrapped.get_action_meanings()[0] == 'NOOP'
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         """Do no-op action for a number of steps in [1, noop_max]."""
         self.env.reset(**kwargs)
         if self.override_num_noops is not None:
@@ -48,7 +48,7 @@ class NoopResetEnv(gym.Wrapper):
                 obs = self.env.reset(**kwargs)
         return obs
 
-    def _step(self, ac):
+    def step(self, ac):
         return self.env.step(ac)
 
 
@@ -59,7 +59,7 @@ class FireResetEnv(gym.Wrapper):
         assert env.unwrapped.get_action_meanings()[1] == 'FIRE'
         assert len(env.unwrapped.get_action_meanings()) >= 3
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         self.env.reset(**kwargs)
         obs, _, done, info = self.env.step(1)
         if done or info.get('needs_reset', False):
@@ -69,7 +69,7 @@ class FireResetEnv(gym.Wrapper):
             self.env.reset(**kwargs)
         return obs
 
-    def _step(self, ac):
+    def step(self, ac):
         return self.env.step(ac)
 
 
@@ -83,7 +83,7 @@ class EpisodicLifeEnv(gym.Wrapper):
         self.lives = 0
         self.needs_real_reset = True
 
-    def _step(self, action):
+    def step(self, action):
         obs, reward, done, info = self.env.step(action)
         self.needs_real_reset = done or info.get('needs_reset', False)
         # check current lives, make loss of life terminal,
@@ -98,7 +98,7 @@ class EpisodicLifeEnv(gym.Wrapper):
         self.lives = lives
         return obs, reward, done, info
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         """Reset only when lives are exhausted.
 
         This way all states are still reachable even though lives are episodic,
@@ -122,7 +122,7 @@ class MaxAndSkipEnv(gym.Wrapper):
             (2,) + env.observation_space.shape, dtype=np.uint8)
         self._skip = skip
 
-    def _step(self, action):
+    def step(self, action):
         """Repeat action, sum reward, and max over last observations."""
         total_reward = 0.0
         done = None
@@ -141,7 +141,7 @@ class MaxAndSkipEnv(gym.Wrapper):
 
         return max_frame, total_reward, done, info
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         return self.env.reset(**kwargs)
 
 
@@ -149,7 +149,7 @@ class ClipRewardEnv(gym.RewardWrapper):
     def __init__(self, env):
         gym.RewardWrapper.__init__(self, env)
 
-    def _reward(self, reward):
+    def reward(self, reward):
         """Bin reward to {+1, 0, -1} by its sign."""
         return np.sign(reward)
 
@@ -173,7 +173,7 @@ class WarpFrame(gym.ObservationWrapper):
             low=0, high=255,
             shape=shape[channel_order], dtype=np.uint8)
 
-    def _observation(self, frame):
+    def observation(self, frame):
         frame = cv2.cvtColor(frame, cv2.COLOR_RGB2GRAY)
         frame = cv2.resize(frame, (self.width, self.height),
                            interpolation=cv2.INTER_AREA)
@@ -200,13 +200,13 @@ class FrameStack(gym.Wrapper):
         self.observation_space = spaces.Box(
             low=low, high=high, dtype=orig_obs_space.dtype)
 
-    def _reset(self):
+    def reset(self):
         ob = self.env.reset()
         for _ in range(self.k):
             self.frames.append(ob)
         return self._get_ob()
 
-    def _step(self, action):
+    def step(self, action):
         ob, reward, done, info = self.env.step(action)
         self.frames.append(ob)
         return self._get_ob(), reward, done, info
@@ -231,11 +231,11 @@ class ScaledFloatFrame(gym.ObservationWrapper):
 
         orig_obs_space = env.observation_space
         self.observation_space = spaces.Box(
-            low=self._observation(orig_obs_space.low),
-            high=self._observation(orig_obs_space.high),
+            low=self.observation(orig_obs_space.low),
+            high=self.observation(orig_obs_space.high),
             dtype=np.float32)
 
-    def _observation(self, observation):
+    def observation(self, observation):
         # careful! This undoes the memory optimization, use
         # with smaller replay buffers only.
         return np.array(observation).astype(np.float32) / self.scale

--- a/chainerrl/wrappers/cast_observation.py
+++ b/chainerrl/wrappers/cast_observation.py
@@ -25,7 +25,7 @@ class CastObservation(gym.ObservationWrapper):
         super().__init__(env)
         self.dtype = dtype
 
-    def _observation(self, observation):
+    def observation(self, observation):
         self.original_observation = observation
         return observation.astype(self.dtype, copy=False)
 

--- a/chainerrl/wrappers/randomize_action.py
+++ b/chainerrl/wrappers/randomize_action.py
@@ -36,7 +36,7 @@ class RandomizeAction(gym.ActionWrapper):
         self._random_fraction = random_fraction
         self._np_random = np.random.RandomState()
 
-    def _action(self, action):
+    def action(self, action):
         if self._np_random.rand() < self._random_fraction:
             return self._np_random.randint(self.env.action_space.n)
         else:

--- a/chainerrl/wrappers/scale_reward.py
+++ b/chainerrl/wrappers/scale_reward.py
@@ -26,6 +26,6 @@ class ScaleReward(gym.RewardWrapper):
         self.scale = scale
         self.original_reward = None
 
-    def _reward(self, reward):
+    def reward(self, reward):
         self.original_reward = reward
         return self.scale * reward

--- a/examples/grasping/README.md
+++ b/examples/grasping/README.md
@@ -10,7 +10,7 @@ This directory contains example scripts that learn to grasp objects in an enviro
 
 ## Requirements
 
-- pybullet>=2.1.2
+- pybullet>=2.4.9
 
 ## How to run
 

--- a/examples/grasping/train_dqn_batch_grasping.py
+++ b/examples/grasping/train_dqn_batch_grasping.py
@@ -32,7 +32,7 @@ class CastAction(gym.ActionWrapper):
         super().__init__(env)
         self.type_ = type_
 
-    def _action(self, action):
+    def action(self, action):
         return self.type_(action)
 
 
@@ -49,7 +49,7 @@ class TransposeObservation(gym.ObservationWrapper):
             dtype=env.observation_space.dtype,
         )
 
-    def _observation(self, observation):
+    def observation(self, observation):
         return observation.transpose(*self._axes)
 
 
@@ -73,7 +73,7 @@ class ObserveElapsedSteps(gym.Wrapper):
         self._elapsed_steps = 0
         return self.env.reset(), self._elapsed_steps
 
-    def _step(self, action):
+    def step(self, action):
         observation, reward, done, info = self.env.step(action)
         self._elapsed_steps += 1
         assert self._elapsed_steps <= self._max_steps

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ chainer>=4.0.0
 fastcache; python_version<'3.2'
 funcsigs; python_version<'3.5'
 future
-gym>=0.9.7,<=0.12.1
+gym>=0.9.7
 numpy>=1.10.4
 pillow
 scipy

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
     'cached-property',
     'chainer>=2.0.0',
     'future',
-    'gym>=0.9.7,<=0.12.1',
+    'gym>=0.9.7',
     'numpy>=1.10.4',
     'pillow',
     'scipy',


### PR DESCRIPTION
- Stop using underscore methods in all the wrappers
- Require `pybullet>=2.4.9` for the grasping example because older ones do not work with `gym>=0.12.2`
- Revert the change requiring `gym<=0.12.1` by https://github.com/chainer/chainerrl/pull/461