### PR TITLE
Apply `noisy_net_sigma` parameter

### DIFF
--- a/examples/ale/train_dqn_ale.py
+++ b/examples/ale/train_dqn_ale.py
@@ -176,7 +176,7 @@ def main():
     q_func = parse_arch(args.arch, n_actions)
 
     if args.noisy_net_sigma is not None:
-        links.to_factorized_noisy(q_func)
+        links.to_factorized_noisy(q_func, sigma_scale=args.noisy_net_sigma)
         # Turn off explorer
         explorer = explorers.Greedy()
     else:

--- a/examples/ale/train_dqn_batch_ale.py
+++ b/examples/ale/train_dqn_batch_ale.py
@@ -174,7 +174,7 @@ def main():
     q_func = parse_arch(args.arch, n_actions)
 
     if args.noisy_net_sigma is not None:
-        links.to_factorized_noisy(q_func)
+        links.to_factorized_noisy(q_func, sigma_scale=args.noisy_net_sigma)
         # Turn off explorer
         explorer = explorers.Greedy()
 

--- a/examples/atari/rainbow/train_rainbow.py
+++ b/examples/atari/rainbow/train_rainbow.py
@@ -99,7 +99,7 @@ def main():
     q_func = DistributionalDuelingDQN(n_actions, n_atoms, v_min, v_max,)
 
     # Noisy nets
-    links.to_factorized_noisy(q_func)
+    links.to_factorized_noisy(q_func, sigma_scale=args.noisy_net_sigma)
     # Turn off explorer
     explorer = explorers.Greedy()
 

--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -137,7 +137,7 @@ def main():
             action_space.sample)
 
     if args.noisy_net_sigma is not None:
-        links.to_factorized_noisy(q_func)
+        links.to_factorized_noisy(q_func, sigma_scale=args.noisy_net_sigma)
         # Turn off explorer
         explorer = explorers.Greedy()
 


### PR DESCRIPTION
The specified value for `noisy_net_sigma` was ignored when NoisyNet is enabled.