### PR TITLE
Adds reference to mujoco folder in the examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,4 +4,5 @@
 - `atari`: examples with benchmark scores for reproducing published results on Atari
 - `gym`: examples for OpenAI Gym environments
 - `grasping`: examples for a Bullet-based robotic grasping environment
+- `mujoco`: examples with benchmark scores for reproducing published results on MuJoCo tasks
 - `quickstart`: a quickstart guide of ChainerRL


### PR DESCRIPTION
We have descriptions of all the subfolders in the examples directory, except for the `mujoco` folder. This PR addresses that.