### PR TITLE
Add CI configs

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -1,0 +1,58 @@
+# ChainerRL GPU unit tests.
+# NOTE: This tests will not run CPU-only tests. CPU-only tests should be tested
+# in chainerrl.py3.cpu.
+# URL: https://ci.preferred.jp/chainerrl.py3.gpu/
+configs {
+  key: "chainerrl.py3.gpu"
+  value {
+    requirement {
+      cpu: 10
+      memory: 30
+      gpu: 1
+    }
+    environment_variables { key: "GPU" value: "1" }
+    command: "bash .pfnci/script.sh py3.gpu"
+  }
+}
+
+# ChainerRL CPU-only unit tests.
+# URL: https://ci.preferred.jp/chainerrl.py3.cpu/
+configs {
+  key: "chainerrl.py3.cpu"
+  value {
+    requirement {
+      cpu: 10
+      memory: 10
+    }
+    command: "bash .pfnci/script.sh py3.cpu"
+  }
+}
+
+# ChainerRL CPU-only unit tests with python2.
+# TODO(chanerrl): Enable this test target. This test does not work because of
+# https://github.com/chainer/chainerrl/issues/463. This should be resolved by
+# preparing a prebuild Docker image with latest Chainer.
+# URL: https://ci.preferred.jp/chainerrl.py2.cpu/
+configs {
+  key: "chainerrl.py2.cpu"
+  value {
+    requirement {
+      cpu: 10
+      memory: 10
+    }
+    command: "bash .pfnci/script.sh py2.cpu"
+  }
+}
+
+# ChainerRL unit tests with Chainer3.
+# URL: https://ci.preferred.jp/chainerrl.py3.chainer4/
+configs {
+  key: "chainerrl.py3.chainer4"
+  value {
+    requirement {
+      cpu: 10
+      memory: 10
+    }
+    command: "bash .pfnci/script.sh py3.chainer4"
+  }
+}

--- a/.pfnci/hint.pbtxt
+++ b/.pfnci/hint.pbtxt
@@ -1,0 +1,16 @@
+# hint.pbtxt is a config file for xpytest.
+#
+# Proto type: xpytest.proto.HintFile
+# https://github.com/chainer/xpytest/blob/master/proto/test_case.proto
+
+# Slow tests take 60+ seconds.
+rules { name: "agents_tests/test_ppo.py" xdist: 4 deadline: 240 }
+rules { name: "agents_tests/test_trpo.py" xdist: 4 deadline: 240 }
+
+# Slow tests take 10+ seconds.
+rules { name: "agents_tests/test_acer.py" }
+rules { name: "agents_tests/test_ale.py" }
+rules { name: "agents_tests/test_trpo.py" }
+rules { name: "policies_tests/test_deterministic_policy.py" }
+rules { name: "q_functions_tests/test_state_action_q_function.py" }
+rules { name: "tests/test_ale.py" }

--- a/.pfnci/run.sh
+++ b/.pfnci/run.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# run.sh is a script to run unit tests inside Docker.  This should be injected
+# by and called from script.sh.
+#
+# Usage: run.sh [target]
+# - target is a test target (e.g., "py37").
+#
+# Environment variables:
+# - GPU (default: 0) ... Set a number of GPUs to GPU.
+#       CAVEAT: Setting GPU>0 disables non-GPU tests, and setting GPU=0 disables
+#               GPU tests.
+
+set -eux
+
+cp -a /src /chainerrl
+mkdir -p /chainerrl/.git
+cd /
+
+# Remove pyc files.  When the CI is triggered with a user's local files, pyc
+# files generated on the user's local machine and they often cause failures.
+find /chainerrl -name "*.pyc" -exec rm -f {} \;
+
+TARGET="$1"
+: "${GPU:=0}"
+: "${XPYTEST_NUM_THREADS:=$(nproc)}"
+: "${PYTHON=python3}"
+: "${CHAINER=}"
+
+# Use multi-process service to prevent GPU flakiness caused by running many
+# processes on a GPU.  Specifically, it seems running more than 16 processes
+# sometimes causes "cudaErrorLaunchFailure: unspecified launch failure".
+if (( GPU > 0 )); then
+    nvidia-smi -c EXCLUSIVE_PROCESS
+    nvidia-cuda-mps-control -d
+fi
+
+################################################################################
+# Main function
+################################################################################
+
+main() {
+  marker='not slow'
+  if (( !GPU )); then
+    marker+=' and not gpu'
+    bucket=1
+  else
+    marker+=' and gpu'
+    bucket="${GPU}"
+  fi
+
+  xpytest_args=(
+      --python="${PYTHON}" -m "${marker}"
+      --bucket="${bucket}" --thread="$(( XPYTEST_NUM_THREADS / bucket ))"
+      --hint="/chainerrl/.pfnci/hint.pbtxt"
+  )
+
+  apt-get update -q
+  apt-get install -qy --no-install-recommends \
+      "${PYTHON}-dev" "${PYTHON}-pip" "${PYTHON}-setuptools" \
+      zlib1g-dev make cmake g++ git
+
+  if [ "${CHAINER}" != '' ]; then
+    "${PYTHON}" -m pip install "chainer==${CHAINER}"
+  fi
+
+  if [ "${PYTHON}" == 'python' ]; then
+    "${PYTHON}" -m pip install \
+        'cython==0.28.0' 'numpy<1.10' 'scipy<0.19' 'more-itertools<=5.0.0'
+  fi
+
+  # TODO(chainerrl): Enable ChainerRL to work without -e.
+  "${PYTHON}" -m pip install -e /chainerrl
+  # TODO(chainerrl): Prepare test target instead.
+  "${PYTHON}" -m pip install \
+      'pytest==4.1.1' 'pytest-xdist==1.26.1' 'mock' \
+      'atari_py==0.1.1' 'opencv-python'
+
+  git config --global user.email "you@example.com"
+  git config --global user.name "Your Name"
+
+  OMP_NUM_THREADS=1 PYTHONHASHSEED=0 \
+      xpytest "${xpytest_args[@]}" '/chainerrl/tests/**/test_*.py'
+}
+
+main

--- a/.pfnci/run.sh
+++ b/.pfnci/run.sh
@@ -68,8 +68,7 @@ main() {
         'cython==0.28.0' 'numpy<1.10' 'scipy<0.19' 'more-itertools<=5.0.0'
   fi
 
-  # TODO(chainerrl): Enable ChainerRL to work without -e.
-  "${PYTHON}" -m pip install -e /chainerrl
+  "${PYTHON}" -m pip install /chainerrl
   # TODO(chainerrl): Prepare test target instead.
   "${PYTHON}" -m pip install \
       'pytest==4.1.1' 'pytest-xdist==1.26.1' 'mock' \

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# script.sh is a script to run Docker for testing.  This is called by CI like
+# "bash .pfnci/script.sh py3.cpu".  If a machine running the script has no
+# GPUs, this should fall back to CPU testing automatically.  This script
+# requires that a corresponding Docker image is accessible from the machine.
+# TODO(imos): Enable external contributors to test this script on their
+# machines.  Specifically, locate a Dockerfile generating chainer-ci-prep.*.
+#
+# Usage: .pfnci/script.sh [target]
+# - target is a test target (e.g., "py3.cpu").
+#
+# Environment variables:
+# - GPU (default: 0) ... Set a number of GPUs to GPU.  GPU=0 disables GPU
+#       testing.
+# - DRYRUN ... Set DRYRUN=1 for local testing.  This disables destructive
+#       actions and make the script print commands.
+# - XPYTEST ... Set XPYTEST=/path/to/xpytest-linux for testing xpytest.  It will
+#       replace xpytest installed inside a Docker image with the given binary.
+#       It should be useful to test xpytest.
+
+set -eu
+
+cd "$(dirname "${BASH_SOURCE}")"/..
+
+################################################################################
+# Main function
+################################################################################
+main() {
+  TARGET="$1"
+
+  # Initialization.
+  prepare_docker &
+  prepare_xpytest &
+  wait
+
+  # Prepare docker args.
+  docker_args=(docker run  --rm --volume="$(pwd):/src:ro")
+  if [ "${GPU:-0}" != '0' ]; then
+    docker_args+=(--ipc=host --privileged --env="GPU=${GPU}" --runtime=nvidia)
+  fi
+  if [ "${XPYTEST:-}" == '' ]; then
+    docker_args+=(--volume="$(pwd)/bin/xpytest:/usr/local/bin/xpytest:ro")
+  else
+    docker_args+=(--volume="${XPYTEST}:/usr/local/bin/xpytest:ro")
+  fi
+  docker_args+=(--env="XPYTEST_NUM_THREADS=${XPYTEST_NUM_THREADS:-$(nproc)}")
+
+  # Determine base image to use.
+  docker_image=ubuntu:18.04
+  chainer_version=
+  case "${TARGET}" in
+    py3.chainer4 ) chainer_version=4.0.0;;
+    # TODO(imos): Use pre-build Docker images instead because latest images are
+    # not updated frequently.
+    py3.cpu | py3.gpu ) docker_image=chainer/chainer:latest-python3;;
+    py2.cpu ) docker_image=chainer/chainer:latest-python2;;
+    # Unsupported targets.
+    * )
+      echo "Unsupported target: ${TARGET}" >&2
+      exit 1
+      ;;
+  esac
+  docker_args+=(--env="CHAINER=${chainer_version}")
+
+  case "${TARGET}" in
+    py2.* ) docker_args+=(--env="PYTHON=python");;
+  esac
+
+  run "${docker_args[@]}" "${docker_image}" bash /src/.pfnci/run.sh "${TARGET}"
+}
+
+################################################################################
+# Utility functions
+################################################################################
+
+# run executes a command.  If DRYRUN is enabled, run just prints the command.
+run() {
+  echo '+' "$@"
+  if [ "${DRYRUN:-}" == '' ]; then
+    "$@"
+  fi
+}
+
+# prepare_docker makes docker use tmpfs to speed up.
+# CAVEAT: Do not use docker during this is running.
+prepare_docker() {
+  # Mount tmpfs to docker's root directory to speed up.
+  if [ "${CI:-}" != '' ]; then
+    run service docker stop
+    run mount -t tmpfs -o size=100% tmpfs /var/lib/docker
+    run service docker start
+  fi
+  # Configure docker to pull images from gcr.io.
+  run gcloud auth configure-docker
+}
+
+# prepare_xpytest prepares xpytest.
+prepare_xpytest() {
+  run mkdir -p bin
+  run gsutil cp gs://ro-pfn-public-ci/package/xpytest/xpytest-linux bin/xpytest
+  run chmod +x bin/xpytest
+}
+
+################################################################################
+# Bootstrap
+################################################################################
+main "$@"


### PR DESCRIPTION
Currently, some imosCI test targets are running, but I'd like to stop them and add the following targets instead:
- https://ci.preferred.jp/chainerrl.py3.gpu/
- https://ci.preferred.jp/chainerrl.py3.cpu/
- https://ci.preferred.jp/chainerrl.py3.chainer4/

The details for each test target should be written in .pfnci/config.pbtxt.