### PR TITLE
Make `to_factorized_noisy` work with sequential links

### DIFF
--- a/chainerrl/links/noisy_chain.py
+++ b/chainerrl/links/noisy_chain.py
@@ -50,5 +50,14 @@ def _map_links(func, link):
                 children[i].name = str(i)
 
                 if isinstance(link, Sequence):
-                    # assumes i-th layer corresponds with i-th child
-                    link.layers[i] = new_child
+                    _replace_unique_item(link.layers, child, new_child)
+                # Check chainer.Sequential if it exists.
+                sequential_class = getattr(chainer, 'Sequential', ())
+                if isinstance(link, sequential_class):
+                    _replace_unique_item(link._layers, child, new_child)
+
+
+def _replace_unique_item(xs, old, new):
+    indices = [i for i, x in enumerate(xs) if x is old]
+    assert len(indices) == 1
+    xs[indices[0]] = new

--- a/tests/links_tests/test_noisy_chain.py
+++ b/tests/links_tests/test_noisy_chain.py
@@ -1,7 +1,9 @@
 import unittest
 
 import chainer
+import chainer.testing
 
+import chainerrl
 from chainerrl.links import to_factorized_noisy
 
 
@@ -43,3 +45,44 @@ class TestToFactorizedNoisy(unittest.TestCase):
             {
                 '/l1', '/l1/mu', '/l1/sigma',
                 '/l2', '/l2/mu', '/l2/sigma', '/l3'})
+
+    def test_sequence(self):
+        ch = chainerrl.links.Sequence(
+            chainer.links.Linear(3),
+            chainer.functions.relu,
+            chainer.links.Linear(4),
+        )
+        self.assertEqual(
+            names_of_links(ch),
+            {'/0', '/1'}
+        )
+        self.assertIs(ch.layers[1], chainer.functions.relu)
+        to_factorized_noisy(ch)
+        self.assertEqual(
+            names_of_links(ch),
+            {
+                '/0', '/0/mu', '/0/sigma',
+                '/1', '/1/mu', '/1/sigma',
+            })
+        self.assertIs(ch.layers[1], chainer.functions.relu)
+
+    @chainer.testing.with_requires('chainer>=5')
+    def test_sequential(self):
+        ch = chainer.Sequential(
+            chainer.links.Linear(3),
+            chainer.functions.relu,
+            chainer.links.Linear(4),
+        )
+        self.assertEqual(
+            names_of_links(ch),
+            {'/0', '/1'}
+        )
+        self.assertIs(ch._layers[1], chainer.functions.relu)
+        to_factorized_noisy(ch)
+        self.assertEqual(
+            names_of_links(ch),
+            {
+                '/0', '/0/mu', '/0/sigma',
+                '/1', '/1/mu', '/1/sigma',
+            })
+        self.assertIs(ch._layers[1], chainer.functions.relu)

--- a/tests/links_tests/test_noisy_chain.py
+++ b/tests/links_tests/test_noisy_chain.py
@@ -2,6 +2,7 @@ import unittest
 
 import chainer
 import chainer.testing
+import numpy
 
 import chainerrl
 from chainerrl.links import to_factorized_noisy
@@ -47,42 +48,56 @@ class TestToFactorizedNoisy(unittest.TestCase):
                 '/l2', '/l2/mu', '/l2/sigma', '/l3'})
 
     def test_sequence(self):
-        ch = chainerrl.links.Sequence(
-            chainer.links.Linear(3),
+        model = chainerrl.links.Sequence(
+            chainer.links.Linear(3, 4),
             chainer.functions.relu,
-            chainer.links.Linear(4),
+            chainer.links.Linear(4, 5),
         )
         self.assertEqual(
-            names_of_links(ch),
+            names_of_links(model),
             {'/0', '/1'}
         )
-        self.assertIs(ch.layers[1], chainer.functions.relu)
-        to_factorized_noisy(ch)
+        self.assertIs(model.layers[1], chainer.functions.relu)
+        to_factorized_noisy(model)
         self.assertEqual(
-            names_of_links(ch),
+            names_of_links(model),
             {
                 '/0', '/0/mu', '/0/sigma',
                 '/1', '/1/mu', '/1/sigma',
             })
-        self.assertIs(ch.layers[1], chainer.functions.relu)
+        self.assertIs(model.layers[1], chainer.functions.relu)
+        model.cleargrads()
+
+        # assert new parameters are used
+        y = model(numpy.ones((2, 3), numpy.float32))
+        chainer.functions.sum(y).backward()
+        for p in model.params():
+            self.assertIsNotNone(p.grad)
 
     @chainer.testing.with_requires('chainer>=5')
     def test_sequential(self):
-        ch = chainer.Sequential(
+        model = chainer.Sequential(
             chainer.links.Linear(3),
             chainer.functions.relu,
             chainer.links.Linear(4),
         )
         self.assertEqual(
-            names_of_links(ch),
+            names_of_links(model),
             {'/0', '/1'}
         )
-        self.assertIs(ch._layers[1], chainer.functions.relu)
-        to_factorized_noisy(ch)
+        self.assertIs(model._layers[1], chainer.functions.relu)
+        to_factorized_noisy(model)
         self.assertEqual(
-            names_of_links(ch),
+            names_of_links(model),
             {
                 '/0', '/0/mu', '/0/sigma',
                 '/1', '/1/mu', '/1/sigma',
             })
-        self.assertIs(ch._layers[1], chainer.functions.relu)
+        self.assertIs(model._layers[1], chainer.functions.relu)
+        model(numpy.ones((2, 3), numpy.float32))
+
+        # assert new parameters are used
+        y = model(numpy.ones((2, 3), numpy.float32))
+        chainer.functions.sum(y).backward()
+        for p in model.params():
+            self.assertIsNotNone(p.grad)


### PR DESCRIPTION
The PR fixes #488 and adds support for `chainer.Sequential`.