### PR TITLE
Fix B006: Do not use mutable data structures for argument defaults.

### DIFF
--- a/chainerrl/experiments/train_agent.py
+++ b/chainerrl/experiments/train_agent.py
@@ -29,7 +29,7 @@ def ask_and_save_agent_replay_buffer(agent, t, outdir, suffix=''):
 
 def train_agent(agent, env, steps, outdir, max_episode_len=None,
                 step_offset=0, evaluator=None, successful_score=None,
-                step_hooks=[], logger=None):
+                step_hooks=(), logger=None):
 
     logger = logger or logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ def train_agent_with_evaluation(agent,
                                 eval_max_episode_len=None,
                                 eval_env=None,
                                 successful_score=None,
-                                step_hooks=[],
+                                step_hooks=(),
                                 save_best_so_far_agent=True,
                                 logger=None,
                                 ):
@@ -123,7 +123,7 @@ def train_agent_with_evaluation(agent,
         eval_env: Environment used for evaluation.
         successful_score (float): Finish training if the mean score is greater
             than or equal to this value if not None
-        step_hooks (list): List of callable objects that accepts
+        step_hooks (Sequence): Sequence of callable objects that accepts
             (env, agent, step) as arguments. They are called every step.
             See chainerrl.experiments.hooks.
         save_best_so_far_agent (bool): If set to True, after each evaluation

--- a/chainerrl/experiments/train_agent_async.py
+++ b/chainerrl/experiments/train_agent_async.py
@@ -19,7 +19,7 @@ def train_loop(process_idx, env, agent, steps, outdir, counter,
                episodes_counter, training_done,
                max_episode_len=None, evaluator=None, eval_env=None,
                successful_score=None, logger=None,
-               global_step_hooks=[]):
+               global_step_hooks=()):
 
     logger = logger or logging.getLogger(__name__)
 
@@ -140,7 +140,7 @@ def train_agent_async(outdir, processes, make_env,
                       successful_score=None,
                       agent=None,
                       make_agent=None,
-                      global_step_hooks=[],
+                      global_step_hooks=(),
                       save_best_so_far_agent=True,
                       logger=None,
                       ):
@@ -164,7 +164,7 @@ def train_agent_async(outdir, processes, make_env,
             or equal to this value if not None
         agent (Agent): Agent to train.
         make_agent (callable): (process_idx) -> Agent
-        global_step_hooks (list): List of callable objects that accepts
+        global_step_hooks (Sequence): Sequence of callable objects that accepts
             (env, agent, step) as arguments. They are called every global
             step. See chainerrl.experiments.hooks.
         save_best_so_far_agent (bool): If set to True, after each evaluation,

--- a/chainerrl/experiments/train_agent_batch.py
+++ b/chainerrl/experiments/train_agent_batch.py
@@ -19,7 +19,7 @@ from chainerrl.misc.makedirs import makedirs
 def train_agent_batch(agent, env, steps, outdir, log_interval=None,
                       max_episode_len=None, eval_interval=None,
                       step_offset=0, evaluator=None, successful_score=None,
-                      step_hooks=[], return_window_size=100, logger=None):
+                      step_hooks=(), return_window_size=100, logger=None):
     """Train an agent in a batch environment.
 
     Args:
@@ -35,7 +35,7 @@ def train_agent_batch(agent, env, steps, outdir, log_interval=None,
             the average returns of the current agent.
         successful_score (float): Finish training if the mean score is greater
             or equal to thisvalue if not None
-        step_hooks (list): List of callable objects that accepts
+        step_hooks (Sequence): Sequence of callable objects that accepts
             (env, agent, step) as arguments. They are called every step.
             See chainerrl.experiments.hooks.
         logger (logging.Logger): Logger used in this function.
@@ -148,7 +148,7 @@ def train_agent_batch_with_evaluation(agent,
                                       eval_env=None,
                                       log_interval=None,
                                       successful_score=None,
-                                      step_hooks=[],
+                                      step_hooks=(),
                                       save_best_so_far_agent=True,
                                       logger=None,
                                       ):
@@ -172,7 +172,7 @@ def train_agent_batch_with_evaluation(agent,
         eval_env: Environment used for evaluation.
         successful_score (float): Finish training if the mean score is greater
             or equal to thisvalue if not None
-        step_hooks (list): List of callable objects that accepts
+        step_hooks (Sequence): Sequence of callable objects that accepts
             (env, agent, step) as arguments. They are called every step.
             See chainerrl.experiments.hooks.
         save_best_so_far_agent (bool): If set to True, after each evaluation,


### PR DESCRIPTION
https://github.com/PyCQA/flake8-bugbear#list-of-warnings

> B006: Do not use mutable data structures for argument defaults. All calls reuse one instance of that data structure, persisting changes between them.