### PR TITLE
Specify ubuntu 16.04 for Travis CI and modify a dependency accordingly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ services:
 before_install:
   - sudo add-apt-repository -y ppa:jonathonf/ffmpeg-4
   - sudo apt-get update
+  - sudo apt install -y freeglut3-dev ffmpeg
 # command to install dependencies
 install:
-  - sudo apt install -y freeglut3-dev ffmpeg
   - pip install --upgrade pip setuptools wheel
   - |
     if [[ $CHAINER_VERSION == 4 ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
 env:
   - CHAINER_VERSION=4
   - CHAINER_VERSION=stable
+services:
+  - xvfb
 before_install:
   - sudo add-apt-repository -y ppa:jonathonf/ffmpeg-4
   - sudo apt-get update
@@ -40,10 +42,6 @@ install:
   - pip install pybullet
   - python setup.py develop
   - python -c "import numpy; numpy.show_config()"
-before_script:
-  - "export DISPLAY=:99.0"
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3
 # command to run tests
 script:
   - flake8 chainerrl

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ services:
 before_install:
   - sudo add-apt-repository -y ppa:jonathonf/ffmpeg-4
   - sudo apt-get update
-  - sudo apt-get install -y ffmpeg
 # command to install dependencies
 install:
+  - sudo apt install -y freeglut3-dev ffmpeg
   - pip install --upgrade pip setuptools wheel
   - |
     if [[ $CHAINER_VERSION == 4 ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 cache: pip
 python:
   - "2.7"
@@ -7,7 +8,7 @@ env:
   - CHAINER_VERSION=4
   - CHAINER_VERSION=stable
 before_install:
-  - sudo add-apt-repository -y ppa:mc3man/trusty-media
+  - sudo add-apt-repository -y ppa:jonathonf/ffmpeg-4
   - sudo apt-get update
   - sudo apt-get install -y ffmpeg
 # command to install dependencies


### PR DESCRIPTION
Resolves #519.

- Specify ubuntu 16.04 (xenial) as a distribution to use in Travis CI. See #519 for the reason.
- Use xvfb service since the previous way does not work with 16.04.
- Install `fleeglut3-dev` to avoid `ImportError: Library "GLU" not found.`