### PR TITLE
Fix import error when chainer==7.0.0b3

### DIFF
--- a/tests/links_tests/test_stateless_recurrent_sequential.py
+++ b/tests/links_tests/test_stateless_recurrent_sequential.py
@@ -10,7 +10,12 @@ import unittest
 
 import chainer
 from chainer import functions as F
-from chainer.functions.connection.n_step_lstm import _lstm
+try:
+    # chainer<=7.0.0b2
+    from chainer.functions.connection.n_step_lstm import _lstm
+except ImportError:
+    # chainer>=7.0.0b3 (https://github.com/chainer/chainer/pull/7725)
+    from chainer.functions.rnn.n_step_lstm import _lstm
 from chainer import links as L
 from chainer import testing
 import numpy as np


### PR DESCRIPTION
Resolves #530 

Reviewer: please test with chainer==7.0.0b3.