### PR TITLE
Use cupyx.scatter_add instead of cupy.scatter_add

### DIFF
--- a/chainerrl/agents/categorical_dqn.py
+++ b/chainerrl/agents/categorical_dqn.py
@@ -51,8 +51,7 @@ def _apply_categorical_projection(y, y_probs, z):
     assert u.shape == (batch_size, n_atoms)
 
     if cuda.available and xp is cuda.cupy:
-        import cupyx
-        scatter_add = cupyx.scatter_add
+        scatter_add = cuda.cupyx.scatter_add
     else:
         scatter_add = np.add.at
 

--- a/chainerrl/agents/categorical_dqn.py
+++ b/chainerrl/agents/categorical_dqn.py
@@ -51,7 +51,8 @@ def _apply_categorical_projection(y, y_probs, z):
     assert u.shape == (batch_size, n_atoms)
 
     if cuda.available and xp is cuda.cupy:
-        scatter_add = xp.scatter_add
+        import cupyx
+        scatter_add = cupyx.scatter_add
     else:
         scatter_add = np.add.at
 


### PR DESCRIPTION
as the latter is deprecated by cupy from v4.

This PR suppresses deprecation warnings from cupy:

> DeprecationWarning: cupy.scatter_add is deprecated. Use cupyx.scatter_add instead.

`cupy.scatter_add` is available from cupy v4, which is the minimum version we support.