### PR TITLE
Improve parameter distributions used in TestGaussianDistribution

### DIFF
--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -191,10 +191,11 @@ class TestMellowmaxDistribution(unittest.TestCase):
 class TestGaussianDistribution(unittest.TestCase):
 
     def setUp(self):
-        self.mean = np.random.rand(
-            self.batch_size, self.ndim).astype(np.float32)
-        self.var = np.random.rand(
-            self.batch_size, self.ndim).astype(np.float32)
+        self.mean = np.random.normal(
+            size=(self.batch_size, self.ndim)).astype(np.float32)
+        self.var = np.random.uniform(
+            low=0.5, high=2.0, size=(self.batch_size, self.ndim)).astype(
+            np.float32)
         self.distrib = distribution.GaussianDistribution(self.mean, self.var)
 
     def test_sample(self):


### PR DESCRIPTION
Before this PR, both mean and var is sampled uniformly from [0,1]. This is not good because
- the case when mean has negative elements is not tested, and
- variance close to zero can lead to numerical instability, leading to failure in tests. (https://ci.preferred.jp/chainerrl.py3.cpu/26601/)

This PR changes the parameter distributions so that mean is sampled from N(0,1) while variance is sampled from U(0.5,2).

I locally ran TestGaussian 100 times without failure.