### PR TITLE
Adds List of Batch Agents to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,21 +36,21 @@ For more information, you can refer to [ChainerRL's documentation](http://chaine
 
 ## Algorithms
 
-| Algorithm | Discrete Action | Continous Action | Recurrent Model | CPU Async Training |
-|:----------|:---------------:|:----------------:|:---------------:|:------------------:|
-| DQN (including DoubleDQN etc.) | ✓ | ✓ (NAF) | ✓ | x |
-| Categorical DQN | ✓ | x | ✓ | x |
-| Rainbow | ✓ | x | ✓ | x |
-| IQN | ✓ | x | ✓ | x |
-| DDPG | x | ✓ | ✓ | x |
-| A3C  | ✓ | ✓ | ✓ | ✓ |
-| ACER | ✓ | ✓ | ✓ | ✓ |
-| NSQ (N-step Q-learning) | ✓ | ✓ (NAF) | ✓ | ✓ |
-| PCL (Path Consistency Learning) | ✓ | ✓ | ✓ | ✓ |
-| PPO  | ✓ | ✓ | ✓ | x |
-| TRPO | ✓ | ✓ | ✓ | x |
-| TD3 | x | ✓ | x | x |
-| SAC | x | ✓ | x | x |
+| Algorithm | Discrete Action | Continous Action | Recurrent Model | Batch Training || CPU Async Training |
+|:----------|:---------------:|:----------------:|:---------------:|:--------------:||:------------------:|
+| DQN (including DoubleDQN etc.) | ✓ | ✓ (NAF) | ✓ | x | x |
+| Categorical DQN | ✓ | x | ✓ | x | x |
+| Rainbow | ✓ | x | ✓ | x | x |
+| IQN | ✓ | x | ✓ | x | x |
+| DDPG | x | ✓ | ✓ | x | x |
+| A3C  | ✓ | ✓ | ✓ | ✓ | ✓ |
+| ACER | ✓ | ✓ | ✓ | ✓ | ✓ |
+| NSQ (N-step Q-learning) | ✓ | ✓ (NAF) | ✓ | ✓ | ✓ |
+| PCL (Path Consistency Learning) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| PPO  | ✓ | ✓ | ✓ | x | x |
+| TRPO | ✓ | ✓ | ✓ | x | x |
+| TD3 | x | ✓ | x | x | x |
+| SAC | x | ✓ | x | x | x |
 
 Following algorithms have been implemented in ChainerRL:
 - [A2C (Synchronous variant of A3C)](https://openai.com/blog/baselines-acktr-a2c/)

--- a/README.md
+++ b/README.md
@@ -36,21 +36,21 @@ For more information, you can refer to [ChainerRL's documentation](http://chaine
 
 ## Algorithms
 
-| Algorithm | Discrete Action | Continous Action | Recurrent Model | Batch Training || CPU Async Training |
-|:----------|:---------------:|:----------------:|:---------------:|:--------------:||:------------------:|
-| DQN (including DoubleDQN etc.) | ✓ | ✓ (NAF) | ✓ | x | x |
-| Categorical DQN | ✓ | x | ✓ | x | x |
-| Rainbow | ✓ | x | ✓ | x | x |
-| IQN | ✓ | x | ✓ | x | x |
-| DDPG | x | ✓ | ✓ | x | x |
-| A3C  | ✓ | ✓ | ✓ | ✓ | ✓ |
-| ACER | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Algorithm | Discrete Action | Continous Action | Recurrent Model | Batch Training | CPU Async Training |
+|:----------|:---------------:|:----------------:|:---------------:|:--------------:|:------------------:|
+| DQN (including DoubleDQN etc.) | ✓ | ✓ (NAF) | ✓ | ✓ | x |
+| Categorical DQN | ✓ | x | ✓ | ✓ | x |
+| Rainbow | ✓ | x | ✓ | ✓ | x |
+| IQN | ✓ | x | ✓ | ✓ | x |
+| DDPG | x | ✓ | ✓ | ✓ | x |
+| A3C  | ✓ | ✓ | ✓ | ✓ (A2C) | ✓ |
+| ACER | ✓ | ✓ | ✓ | x | ✓ |
 | NSQ (N-step Q-learning) | ✓ | ✓ (NAF) | ✓ | ✓ | ✓ |
-| PCL (Path Consistency Learning) | ✓ | ✓ | ✓ | ✓ | ✓ |
-| PPO  | ✓ | ✓ | ✓ | x | x |
-| TRPO | ✓ | ✓ | ✓ | x | x |
-| TD3 | x | ✓ | x | x | x |
-| SAC | x | ✓ | x | x | x |
+| PCL (Path Consistency Learning) | ✓ | ✓ | ✓ | x | ✓ |
+| PPO  | ✓ | ✓ | ✓ | ✓ | x |
+| TRPO | ✓ | ✓ | ✓ | ✓ | x |
+| TD3 | x | ✓ | x | ✓ | x |
+| SAC | x | ✓ | x | ✓ | x |
 
 Following algorithms have been implemented in ChainerRL:
 - [A2C (Synchronous variant of A3C)](https://openai.com/blog/baselines-acktr-a2c/)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For more information, you can refer to [ChainerRL's documentation](http://chaine
 | DDPG | x | ✓ | ✓ | ✓ | x |
 | A3C  | ✓ | ✓ | ✓ | ✓ (A2C) | ✓ |
 | ACER | ✓ | ✓ | ✓ | x | ✓ |
-| NSQ (N-step Q-learning) | ✓ | ✓ (NAF) | ✓ | ✓ | ✓ |
+| NSQ (N-step Q-learning) | ✓ | ✓ (NAF) | ✓ | x | ✓ |
 | PCL (Path Consistency Learning) | ✓ | ✓ | ✓ | x | ✓ |
 | PPO  | ✓ | ✓ | ✓ | ✓ | x |
 | TRPO | ✓ | ✓ | ✓ | ✓ | x |


### PR DESCRIPTION
We currently don't specify in the README whether an agent is a batch agent or not. This PR does this.

Source for the data:

DQN, DDPG, PPO, TRPO, TD3, PCL, and SAC are batch agents by definition.

Categorical DQN, Rainbow (CategoricalDoubleDQN), and IQN are BatchAgents by inheriting DQN.

A3C is a BatchAgent via A2C. 
NSQ is a BatchAgent via normal DQN with an N-Step buffer. Not sure how factually correct we're trying to be in calling these two agents "Batch" agents.

ACER is simply not a batch agent.

