### PR TITLE
Increase flexCI's time limit to 20min

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -10,6 +10,9 @@ configs {
       memory: 30
       gpu: 1
     }
+    time_limit {
+      seconds: 1200
+    }
     environment_variables { key: "GPU" value: "1" }
     command: "bash .pfnci/script.sh py3.gpu"
   }
@@ -23,6 +26,9 @@ configs {
     requirement {
       cpu: 10
       memory: 10
+    }
+    time_limit {
+      seconds: 1200
     }
     command: "bash .pfnci/script.sh py3.cpu"
   }
@@ -52,6 +58,9 @@ configs {
     requirement {
       cpu: 10
       memory: 10
+    }
+    time_limit {
+      seconds: 1200
     }
     command: "bash .pfnci/script.sh py3.chainer4"
   }


### PR DESCRIPTION
Default is 10min. I skipped `chainerrl.py2.cpu` because it is not used.