### PR TITLE
Fixes Rainbow Score to use correct Reporting Protocol

### DIFF
--- a/examples/atari/reproduction/rainbow/README.md
+++ b/examples/atari/reproduction/rainbow/README.md
@@ -26,76 +26,80 @@ These results reflect ChainerRL  `v0.7.0`.
 
 | Results Summary ||
 | ------------- |:-------------:|
+| Reporting Protocol | A re-evaluation of the best intermediate agent |
 | Number of seeds | 1 |
 | Number of common domains | 52 |
-| Number of domains where paper scores higher | 22 |
-| Number of domains where ChainerRL scores higher | 29 |
-| Number of ties between paper and ChainerRL | 1 |
+| Number of domains where paper scores higher | 17 |
+| Number of domains where ChainerRL scores higher | 34 |
+| Number of ties between paper and ChainerRL | 1 | 
 
 
+
+Comparison against original reported results...
 | Game        | ChainerRL Score           | Original Reported Scores |
 | ------------- |:-------------:|:-------------:|
-| AirRaid | 8447.9| N/A|
-| Alien | **12163.2**| 9491.7|
-| Amidar | 4697.4| **5131.2**|
-| Assault | **18425.9**| 14198.5|
-| Asterix | 298025.0| **428200.3**|
-| Asteroids | **5131.2**| 2712.8|
-| Atlantis | **851950.0**| 826659.5|
-| BankHeist | **1630.5**| 1358.0|
-| BattleZone | **98923.1**| 62010.0|
-| BeamRider | **19279.4**| 16850.2|
-| Berzerk | **3757.2**| 2545.6|
-| Bowling | **45.0**| 30.0|
-| Boxing | **99.8**| 99.6|
-| Breakout | 351.8| **417.5**|
-| Carnival | 4446.0| N/A|
-| Centipede | **8337.6**| 8167.3|
-| ChopperCommand | 9068.4| **16654.0**|
-| CrazyClimber | 163036.0| **168788.5**|
+| AirRaid | 7637.9| N/A|
+| Alien | **14070.0**| 9491.7|
+| Amidar | 4863.4| **5131.2**|
+| Assault | **15224.3**| 14198.5|
+| Asterix | **579136.5**| 428200.3|
+| Asteroids | **4822.1**| 2712.8|
+| Atlantis | **909249.0**| 826659.5|
+| BankHeist | **1625.8**| 1358.0|
+| BattleZone | **88680.0**| 62010.0|
+| BeamRider | **18645.4**| 16850.2|
+| Berzerk | **3616.7**| 2545.6|
+| Bowling | **68.3**| 30.0|
+| Boxing | **100.0**| 99.6|
+| Breakout | 329.5| **417.5**|
+| Carnival | 4450.0| N/A|
+| Centipede | **8928.9**| 8167.3|
+| ChopperCommand | 9681.0| **16654.0**|
+| CrazyClimber | 153402.5| **168788.5**|
 | Defender | N/A| 55105.0|
-| DemonAttack | 104041.3| **111185.2**|
-| DoubleDunk | **0.0**| -0.3|
-| Enduro | **2311.3**| 2125.9|
-| FishingDerby | **40.9**| 31.3|
-| Freeway | 33.3| **34.0**|
-| Frostbite | **10497.6**| 9590.5|
-| Gopher | **98084.0**| 70354.6|
-| Gravitar | 1302.5| **1419.3**|
-| Hero | 30907.1| **55887.4**|
-| IceHockey | **2.9**| 1.1|
-| Jamesbond | 21323.2| N/A|
-| JourneyEscape | -185.3| N/A|
-| Kangaroo | **15500.0**| 14637.5|
-| Krull | 6761.6| **8741.5**|
-| KungFuMaster | 39858.3| **52181.0**|
+| DemonAttack | 104304.1| **111185.2**|
+| DoubleDunk | -0.7| **-0.3**|
+| Enduro | **2298.7**| 2125.9|
+| FishingDerby | **42.0**| 31.3|
+| Freeway | 33.5| **34.0**|
+| Frostbite | **11324.3**| 9590.5|
+| Gopher | **89685.7**| 70354.6|
+| Gravitar | **1420.0**| 1419.3|
+| Hero | 36184.2| **55887.4**|
+| IceHockey | **3.3**| 1.1|
+| Jamesbond | 21157.5| N/A|
+| JourneyEscape | -63.5| N/A|
+| Kangaroo | **15498.5**| 14637.5|
+| Krull | 8444.8| **8741.5**|
+| KungFuMaster | 36593.5| **52181.0**|
 | MontezumaRevenge | 0.0| **384.0**|
-| MsPacman | **6015.4**| 5380.4|
-| NameThisGame | 13092.1| **13136.0**|
-| Phoenix | **223676.3**| 108528.6|
-| Pitfall | -3.5| 0.0|
+| MsPacman | **5593.9**| 5380.4|
+| NameThisGame | **13591.4**| 13136.0|
+| Phoenix | **261011.3**| 108528.6|
+| Pitfall | -0.2| **0.0**|
 | Pong | **21.0**| 20.9|
-| Pooyan | 7946.6| N/A|
-| PrivateEye | 100.0| **4234.0**|
-| Qbert | **38605.7**| 33817.5|
-| Riverraid | 22309.8| N/A|
-| RoadRunner | **64002.0**| 62041.0|
-| Robotank | **74.5**| 61.4|
-| Seaquest | 1843.6| **15898.9**|
-| Skiing | **-11093.2**| -12957.8|
-| Solaris | 911.8| **3560.3**|
-| SpaceInvaders | 2812.9| **18789.0**|
-| StarGunner | **202136.4**| 127029.0|
+| Pooyan | 12462.4| N/A|
+| PrivateEye | 86.0| **4234.0**|
+| Qbert | **42774.6**| 33817.5|
+| Riverraid | 21264.0| N/A|
+| RoadRunner | **63157.0**| 62041.0|
+| Robotank | **74.2**| 61.4|
+| Seaquest | 1849.8| **15898.9**|
+| Skiing | **-9741.2**| -12957.8|
+| Solaris | **6649.4**| 3560.3|
+| SpaceInvaders | 2848.7| **18789.0**|
+| StarGunner | **207200.0**| 127029.0|
 | Surround | N/A| 9.7|
-| Tennis | **0.0**| **0.0**|
-| TimePilot | **23123.8**| 12926.0|
-| Tutankham | **250.7**| 241.0|
-| UpNDown | 27630.0| N/A|
-| Venture | 0.0| **5.5**|
-| VideoPinball | 438907.9| **533936.5**|
-| WizardOfWor | **20770.2**| 17862.5|
-| YarsRevenge | 101023.5| **102557.0**|
-| Zaxxon | 14635.1| **22209.5**|
+| Tennis | **-0.0**| **0.0**|
+| TimePilot | **23810.5**| 12926.0|
+| Tutankham | **266.7**| 241.0|
+| UpNDown | 67551.6| N/A|
+| Venture | **12.0**| 5.5|
+| VideoPinball | 363333.4| **533936.5**|
+| WizardOfWor | **22872.0**| 17862.5|
+| YarsRevenge | **111187.8**| 102557.0|
+| Zaxxon | 21884.0| **22209.5**|
+
 
 
 

--- a/examples/atari/reproduction/rainbow/README.md
+++ b/examples/atari/reproduction/rainbow/README.md
@@ -34,8 +34,6 @@ These results reflect ChainerRL  `v0.7.0`.
 | Number of ties between paper and ChainerRL | 1 | 
 
 
-
-Comparison against original reported results...
 | Game        | ChainerRL Score           | Original Reported Scores |
 | ------------- |:-------------:|:-------------:|
 | AirRaid | 7637.9| N/A|
@@ -99,6 +97,7 @@ Comparison against original reported results...
 | WizardOfWor | **22872.0**| 17862.5|
 | YarsRevenge | **111187.8**| 102557.0|
 | Zaxxon | 21884.0| **22209.5**|
+
 
 
 

--- a/examples/pretrained/load_model.py
+++ b/examples/pretrained/load_model.py
@@ -89,7 +89,6 @@ def cached_download(url):
     except OSError:
         if not os.path.exists(cache_root):
             raise
-    set_trace()
     lock_path = os.path.join(cache_root, '_dl_lock')
     urlhash = hashlib.md5(url.encode('utf-8')).hexdigest()
     cache_path = os.path.join(cache_root, urlhash)
@@ -113,10 +112,9 @@ def cached_download(url):
     finally:
         shutil.rmtree(temp_root)
 
-    set_trace()
     return cache_path
 
-def download_and_store_model(url, env, model_type):
+def download_and_store_model(alg, url, env, model_type):
     """Downloads a model file and puts it under model directory.
     It downloads a file from the URL and puts it under model directory.
     For exmaple, if :obj:`url` is `http://example.com/subdir/model.npz`,
@@ -138,23 +136,32 @@ def download_and_store_model(url, env, model_type):
             get_dataset_directory(os.path.join('pfnet', 'chainerrl', '.lock')),
             'models.lock')):
         root = get_dataset_directory(
-            os.path.join('pfnet', 'chainerrl', 'models'))
-        url_path = os.path.join(url, env,
-                                model_type_to_path[model_type],
-                                PRETRAINED_MODELS["DQN"][0])
-        basename = os.path.basename(url_path)
-        path = os.path.join(root, basename)
-        print(path)
-        if not os.path.exists(path):
-            cache_path = cached_download(url_path)
-            os.rename(cache_path, path)
+            os.path.join('pfnet', 'chainerrl', 'models', alg, env, model_type_to_path[model_type]))
+        url_basepath = os.path.join(url, env,
+                                model_type_to_path[model_type])
+        url_paths = []
+        for file in PRETRAINED_MODELS["DQN"]:
+            # url_paths.append(os.path.join(url_basepath,
+            #                     file))
+            path = os.path.join(root, file)
+            if not os.path.exists(path):
+                cache_path = cached_download(os.path.join(url_basepath,
+                                             file))
+                os.rename(cache_path, path)
+        return root
+        # basename = os.path.basename(url_path)
+        # path = os.path.join(root, basename)
+        # print(path)
+        # if not os.path.exists(path):
+        #     cache_path = cached_download(url_path)
+            # os.rename(cache_path, path)
         return path
 
-def download_model(algorithm, env, model_type="best"):
+def download_model(alg, env, model_type="best"):
     assert model_type in ("best", "final")
-    assert algorithm in ["DQN"]
+    assert alg in ["DQN"]
     env = env.replace("NoFrameskip-v4", "")
-    model_path = download_and_store_model(url, env, model_type)
+    model_path = download_and_store_model(alg, url, env, model_type)
     set_trace()
 
 def main():

--- a/examples/pretrained/load_model.py
+++ b/examples/pretrained/load_model.py
@@ -1,0 +1,310 @@
+'''
+This file is forked from ChainerCV.
+'''
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()  # NOQA
+
+import argparse
+from distutils.util import strtobool
+import filelock
+import hashlib
+import os
+import shutil
+import tempfile
+import time
+import sys
+from six.moves.urllib import request
+
+from chainer.dataset.download import get_dataset_directory
+from chainer.dataset.download import get_dataset_root
+from chainer import links as L
+from chainer import optimizers
+import numpy as np
+
+import chainerrl
+from chainerrl.action_value import DiscreteActionValue
+from chainerrl import agents
+from chainerrl import experiments
+from chainerrl import explorers
+from chainerrl import links
+from chainerrl import misc
+from chainerrl import replay_buffer
+
+from chainerrl.wrappers import atari_wrappers
+import json
+from pdb import set_trace
+
+
+PRETRAINED_MODELS = {"DQN": ["model.npz","target_model.npz", "optimizer.npz"],
+}
+url = "https://chainer-assets.preferred.jp/chainerrl/"
+
+
+def _reporthook(count, block_size, total_size):
+    global start_time
+    if count == 0:
+        start_time = time.time()
+        print('  %   Total    Recv       Speed  Time left')
+        return
+    duration = time.time() - start_time
+    progress_size = count * block_size
+    try:
+        speed = progress_size / duration
+    except ZeroDivisionError:
+        speed = float('inf')
+    percent = progress_size / total_size * 100
+    eta = int((total_size - progress_size) / speed)
+    sys.stdout.write(
+        '\r{:3.0f} {:4.0f}MiB {:4.0f}MiB {:6.0f}KiB/s {:4d}:{:02d}:{:02d}'
+        .format(
+            percent, total_size / (1 << 20), progress_size / (1 << 20),
+            speed / (1 << 10), eta // 60 // 60, (eta // 60) % 60, eta % 60))
+    sys.stdout.flush()
+
+
+def cached_download(url):
+    """Downloads a file and caches it.
+    This is different from the original
+    :func:`~chainer.dataset.cached_download` in that the download
+    progress is reported. Note that this progress report can be disabled
+    by setting the environment variable `CHAINERCV_DOWNLOAD_REPORT` to `'OFF'`.
+    It downloads a file from the URL if there is no corresponding cache. After
+    the download, this function stores a cache to the directory under the
+    dataset root (see :func:`set_dataset_root`). If there is already a cache
+    for the given URL, it just returns the path to the cache without
+    downloading the same file.
+    Args:
+        url (string): URL to download from.
+    Returns:
+        string: Path to the downloaded file.
+    """
+    cache_root = os.path.join(get_dataset_root(), '_dl_cache')
+    try:
+        os.makedirs(cache_root)
+    except OSError:
+        if not os.path.exists(cache_root):
+            raise
+    set_trace()
+    lock_path = os.path.join(cache_root, '_dl_lock')
+    urlhash = hashlib.md5(url.encode('utf-8')).hexdigest()
+    cache_path = os.path.join(cache_root, urlhash)
+
+    with filelock.FileLock(lock_path):
+        if os.path.exists(cache_path):
+            return cache_path
+
+    temp_root = tempfile.mkdtemp(dir=cache_root)
+    try:
+        temp_path = os.path.join(temp_root, 'dl')
+        if strtobool(os.getenv('CHAINERRL_DOWNLOAD_REPORT', 'ON')):
+            print('Downloading ...')
+            print('From: {:s}'.format(url))
+            print('To: {:s}'.format(cache_path))
+            request.urlretrieve(url, temp_path, _reporthook)
+        else:
+            request.urlretrieve(url, temp_path)
+        with filelock.FileLock(lock_path):
+            shutil.move(temp_path, cache_path)
+    finally:
+        shutil.rmtree(temp_root)
+
+    set_trace()
+    return cache_path
+
+def download_and_store_model(url, env, model_type):
+    """Downloads a model file and puts it under model directory.
+    It downloads a file from the URL and puts it under model directory.
+    For exmaple, if :obj:`url` is `http://example.com/subdir/model.npz`,
+    the pretrained weights file will be saved to
+    `$CHAINER_DATASET_ROOT/pfnet/chainercv/models/model.npz`.
+    If there is already a file at the destination path,
+    it just returns the path without downloading the same file.
+    Args:
+        url (string): URL to download from.
+    Returns:
+        string: Path to the downloaded file.
+    """
+    # To support ChainerMN, the target directory should be locked.
+    model_type_to_path = {
+    "best" : "best",
+    "final" : "5000000_finish"
+    }
+    with filelock.FileLock(os.path.join(
+            get_dataset_directory(os.path.join('pfnet', 'chainerrl', '.lock')),
+            'models.lock')):
+        root = get_dataset_directory(
+            os.path.join('pfnet', 'chainerrl', 'models'))
+        url_path = os.path.join(url, env,
+                                model_type_to_path[model_type],
+                                PRETRAINED_MODELS["DQN"][0])
+        basename = os.path.basename(url_path)
+        path = os.path.join(root, basename)
+        print(path)
+        if not os.path.exists(path):
+            cache_path = cached_download(url_path)
+            os.rename(cache_path, path)
+        return path
+
+def download_model(algorithm, env, model_type="best"):
+    assert model_type in ("best", "final")
+    assert algorithm in ["DQN"]
+    env = env.replace("NoFrameskip-v4", "")
+    model_path = download_and_store_model(url, env, model_type)
+    set_trace()
+
+def main():
+    download_model("DQN", "ChopperCommandNoFrameskip-v4")
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--env', type=str, default='ChopperCommandNoFrameskip-v4',
+                        help='OpenAI Atari domain to perform algorithm on.')
+    parser.add_argument('--outdir', type=str, default='results',
+                        help='Directory path to save output files.'
+                             ' If it does not exist, it will be created.')
+    parser.add_argument('--seed', type=int, default=0,
+                        help='Random seed [0, 2 ** 31)')
+    parser.add_argument('--gpu', type=int, default=0,
+                        help='GPU to use, set to -1 if no GPU.')
+    parser.add_argument('--demo', action='store_true', default=False)
+    parser.add_argument('--load', type=str, default=None)
+    parser.add_argument('--logging-level', type=int, default=20,
+                        help='Logging level. 10:DEBUG, 20:INFO etc.')
+    parser.add_argument('--render', action='store_true', default=False,
+                        help='Render env states in a GUI window.')
+    parser.add_argument('--monitor', action='store_true', default=False,
+                        help='Monitor env. Videos and additional information'
+                             ' are saved as output files.')
+    parser.add_argument('--steps', type=int, default=5 * 10 ** 7,
+                        help='Total number of timesteps to train the agent.')
+    parser.add_argument('--replay-start-size', type=int, default=5 * 10 ** 4,
+                        help='Minimum replay buffer size before ' +
+                        'performing gradient updates.')
+    parser.add_argument('--eval-n-steps', type=int, default=125000)
+    parser.add_argument('--eval-interval', type=int, default=250000)
+    parser.add_argument('--n-best-episodes', type=int, default=30)
+    args = parser.parse_args()
+
+    import logging
+    logging.basicConfig(level=args.logging_level)
+
+    # Set a random seed used in ChainerRL.
+    misc.set_random_seed(args.seed, gpus=(args.gpu,))
+
+    # Set different random seeds for train and test envs.
+    train_seed = args.seed
+    test_seed = 2 ** 31 - 1 - args.seed
+
+    args.outdir = experiments.prepare_output_dir(args, args.outdir)
+    print('Output files are saved in {}'.format(args.outdir))
+
+    def make_env(test):
+        # Use different random seeds for train and test envs
+        env_seed = test_seed if test else train_seed
+        env = atari_wrappers.wrap_deepmind(
+            atari_wrappers.make_atari(args.env, max_frames=None),
+            episode_life=not test,
+            clip_rewards=not test)
+        env.seed(int(env_seed))
+        if test:
+            # Randomize actions like epsilon-greedy in evaluation as well
+            env = chainerrl.wrappers.RandomizeAction(env, 0.05)
+        if args.monitor:
+            env = chainerrl.wrappers.Monitor(
+                env, args.outdir,
+                mode='evaluation' if test else 'training')
+        if args.render:
+            env = chainerrl.wrappers.Render(env)
+        return env
+
+    env = make_env(test=False)
+    eval_env = make_env(test=True)
+
+    n_actions = env.action_space.n
+    q_func = links.Sequence(
+        links.NatureDQNHead(),
+        L.Linear(512, n_actions),
+        DiscreteActionValue)
+
+    # Draw the computational graph and save it in the output directory.
+    chainerrl.misc.draw_computational_graph(
+        [q_func(np.zeros((4, 84, 84), dtype=np.float32)[None])],
+        os.path.join(args.outdir, 'model'))
+
+    # Use the same hyperparameters as the Nature paper
+    opt = optimizers.RMSpropGraves(
+        lr=2.5e-4, alpha=0.95, momentum=0.0, eps=1e-2)
+
+    opt.setup(q_func)
+
+    rbuf = replay_buffer.ReplayBuffer(10 ** 6)
+
+    explorer = explorers.LinearDecayEpsilonGreedy(
+        start_epsilon=1.0, end_epsilon=0.1,
+        decay_steps=10 ** 6,
+        random_action_func=lambda: np.random.randint(n_actions))
+
+    def phi(x):
+        # Feature extractor
+        return np.asarray(x, dtype=np.float32) / 255
+
+    Agent = agents.DQN
+    agent = Agent(q_func, opt, rbuf, gpu=args.gpu, gamma=0.99,
+                  explorer=explorer, replay_start_size=args.replay_start_size,
+                  target_update_interval=10 ** 4,
+                  clip_delta=True,
+                  update_interval=4,
+                  batch_accumulator='sum',
+                  phi=phi)
+
+    if args.load:
+        agent.load(args.load)
+
+    if args.demo:
+        eval_stats = experiments.eval_performance(
+            env=eval_env,
+            agent=agent,
+            n_steps=args.eval_n_steps,
+            n_episodes=None)
+        print('n_episodes: {} mean: {} median: {} stdev {}'.format(
+            eval_stats['episodes'],
+            eval_stats['mean'],
+            eval_stats['median'],
+            eval_stats['stdev']))
+    else:
+        experiments.train_agent_with_evaluation(
+            agent=agent, env=env, steps=args.steps,
+            eval_n_steps=args.eval_n_steps,
+            eval_n_episodes=None,
+            eval_interval=args.eval_interval,
+            outdir=args.outdir,
+            save_best_so_far_agent=True,
+            eval_env=eval_env,
+        )
+
+        dir_of_best_network = os.path.join(args.outdir, "best")
+        agent.load(dir_of_best_network)
+
+        # run 30 evaluation episodes, each capped at 5 mins of play
+        stats = experiments.evaluator.eval_performance(
+            env=eval_env,
+            agent=agent,
+            n_steps=None,
+            n_episodes=args.n_best_episodes,
+            max_episode_len=4500,
+            logger=None)
+        with open(os.path.join(args.outdir, 'bestscores.json'), 'w') as f:
+            # temporary hack to handle python 2/3 support issues.
+            # json dumps does not support non-string literal dict keys
+            json_stats = json.dumps(stats)
+            print(str(json_stats), file=f)
+        print("The results of the best scoring network:")
+        for stat in stats:
+            print(str(stat) + ":" + str(stats[stat]))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Currently, the Rainbow scores show the scores of the final agent, as opposed to a re-evaluation of the best intermediate network.

The new README looks like this: https://github.com/prabhatnagarajan/chainerrl/tree/fixed_scores/examples/atari/reproduction/rainbow