### PR TITLE
Fixes Rainbow Score to use correct Reporting Protocol

### DIFF
--- a/examples/atari/reproduction/rainbow/README.md
+++ b/examples/atari/reproduction/rainbow/README.md
@@ -26,76 +26,79 @@ These results reflect ChainerRL  `v0.7.0`.
 
 | Results Summary ||
 | ------------- |:-------------:|
+| Reporting Protocol | A re-evaluation of the best intermediate agent |
 | Number of seeds | 1 |
 | Number of common domains | 52 |
-| Number of domains where paper scores higher | 22 |
-| Number of domains where ChainerRL scores higher | 29 |
-| Number of ties between paper and ChainerRL | 1 |
+| Number of domains where paper scores higher | 17 |
+| Number of domains where ChainerRL scores higher | 34 |
+| Number of ties between paper and ChainerRL | 1 | 
 
 
 | Game        | ChainerRL Score           | Original Reported Scores |
 | ------------- |:-------------:|:-------------:|
-| AirRaid | 8447.9| N/A|
-| Alien | **12163.2**| 9491.7|
-| Amidar | 4697.4| **5131.2**|
-| Assault | **18425.9**| 14198.5|
-| Asterix | 298025.0| **428200.3**|
-| Asteroids | **5131.2**| 2712.8|
-| Atlantis | **851950.0**| 826659.5|
-| BankHeist | **1630.5**| 1358.0|
-| BattleZone | **98923.1**| 62010.0|
-| BeamRider | **19279.4**| 16850.2|
-| Berzerk | **3757.2**| 2545.6|
-| Bowling | **45.0**| 30.0|
-| Boxing | **99.8**| 99.6|
-| Breakout | 351.8| **417.5**|
-| Carnival | 4446.0| N/A|
-| Centipede | **8337.6**| 8167.3|
-| ChopperCommand | 9068.4| **16654.0**|
-| CrazyClimber | 163036.0| **168788.5**|
+| AirRaid | 7637.9| N/A|
+| Alien | **14070.0**| 9491.7|
+| Amidar | 4863.4| **5131.2**|
+| Assault | **15224.3**| 14198.5|
+| Asterix | **579136.5**| 428200.3|
+| Asteroids | **4822.1**| 2712.8|
+| Atlantis | **909249.0**| 826659.5|
+| BankHeist | **1625.8**| 1358.0|
+| BattleZone | **88680.0**| 62010.0|
+| BeamRider | **18645.4**| 16850.2|
+| Berzerk | **3616.7**| 2545.6|
+| Bowling | **68.3**| 30.0|
+| Boxing | **100.0**| 99.6|
+| Breakout | 329.5| **417.5**|
+| Carnival | 4450.0| N/A|
+| Centipede | **8928.9**| 8167.3|
+| ChopperCommand | 9681.0| **16654.0**|
+| CrazyClimber | 153402.5| **168788.5**|
 | Defender | N/A| 55105.0|
-| DemonAttack | 104041.3| **111185.2**|
-| DoubleDunk | **0.0**| -0.3|
-| Enduro | **2311.3**| 2125.9|
-| FishingDerby | **40.9**| 31.3|
-| Freeway | 33.3| **34.0**|
-| Frostbite | **10497.6**| 9590.5|
-| Gopher | **98084.0**| 70354.6|
-| Gravitar | 1302.5| **1419.3**|
-| Hero | 30907.1| **55887.4**|
-| IceHockey | **2.9**| 1.1|
-| Jamesbond | 21323.2| N/A|
-| JourneyEscape | -185.3| N/A|
-| Kangaroo | **15500.0**| 14637.5|
-| Krull | 6761.6| **8741.5**|
-| KungFuMaster | 39858.3| **52181.0**|
+| DemonAttack | 104304.1| **111185.2**|
+| DoubleDunk | -0.7| **-0.3**|
+| Enduro | **2298.7**| 2125.9|
+| FishingDerby | **42.0**| 31.3|
+| Freeway | 33.5| **34.0**|
+| Frostbite | **11324.3**| 9590.5|
+| Gopher | **89685.7**| 70354.6|
+| Gravitar | **1420.0**| 1419.3|
+| Hero | 36184.2| **55887.4**|
+| IceHockey | **3.3**| 1.1|
+| Jamesbond | 21157.5| N/A|
+| JourneyEscape | -63.5| N/A|
+| Kangaroo | **15498.5**| 14637.5|
+| Krull | 8444.8| **8741.5**|
+| KungFuMaster | 36593.5| **52181.0**|
 | MontezumaRevenge | 0.0| **384.0**|
-| MsPacman | **6015.4**| 5380.4|
-| NameThisGame | 13092.1| **13136.0**|
-| Phoenix | **223676.3**| 108528.6|
-| Pitfall | -3.5| 0.0|
+| MsPacman | **5593.9**| 5380.4|
+| NameThisGame | **13591.4**| 13136.0|
+| Phoenix | **261011.3**| 108528.6|
+| Pitfall | -0.2| **0.0**|
 | Pong | **21.0**| 20.9|
-| Pooyan | 7946.6| N/A|
-| PrivateEye | 100.0| **4234.0**|
-| Qbert | **38605.7**| 33817.5|
-| Riverraid | 22309.8| N/A|
-| RoadRunner | **64002.0**| 62041.0|
-| Robotank | **74.5**| 61.4|
-| Seaquest | 1843.6| **15898.9**|
-| Skiing | **-11093.2**| -12957.8|
-| Solaris | 911.8| **3560.3**|
-| SpaceInvaders | 2812.9| **18789.0**|
-| StarGunner | **202136.4**| 127029.0|
+| Pooyan | 12462.4| N/A|
+| PrivateEye | 86.0| **4234.0**|
+| Qbert | **42774.6**| 33817.5|
+| Riverraid | 21264.0| N/A|
+| RoadRunner | **63157.0**| 62041.0|
+| Robotank | **74.2**| 61.4|
+| Seaquest | 1849.8| **15898.9**|
+| Skiing | **-9741.2**| -12957.8|
+| Solaris | **6649.4**| 3560.3|
+| SpaceInvaders | 2848.7| **18789.0**|
+| StarGunner | **207200.0**| 127029.0|
 | Surround | N/A| 9.7|
-| Tennis | **0.0**| **0.0**|
-| TimePilot | **23123.8**| 12926.0|
-| Tutankham | **250.7**| 241.0|
-| UpNDown | 27630.0| N/A|
-| Venture | 0.0| **5.5**|
-| VideoPinball | 438907.9| **533936.5**|
-| WizardOfWor | **20770.2**| 17862.5|
-| YarsRevenge | 101023.5| **102557.0**|
-| Zaxxon | 14635.1| **22209.5**|
+| Tennis | **-0.0**| **0.0**|
+| TimePilot | **23810.5**| 12926.0|
+| Tutankham | **266.7**| 241.0|
+| UpNDown | 67551.6| N/A|
+| Venture | **12.0**| 5.5|
+| VideoPinball | 363333.4| **533936.5**|
+| WizardOfWor | **22872.0**| 17862.5|
+| YarsRevenge | **111187.8**| 102557.0|
+| Zaxxon | 21884.0| **22209.5**|
+
+
 
 
 


### PR DESCRIPTION
Currently, the Rainbow scores show the scores of the final agent, as opposed to a re-evaluation of the best intermediate network.

The new README looks like this: https://github.com/prabhatnagarajan/chainerrl/tree/fix_rainbow_scores/examples/atari/reproduction/rainbow
