### PR TITLE
Adds time to DDPG Tests

### DIFF
--- a/.pfnci/hint.pbtxt
+++ b/.pfnci/hint.pbtxt
@@ -4,7 +4,7 @@
 # https://github.com/chainer/xpytest/blob/master/proto/test_case.proto
 
 # Slow tests take 60+ seconds.
-rules { name: "agents_tests/test_ddpg.py" xdist: 4 deadline: 480 }
+rules { name: "agents_tests/test_ddpg.py" xdist: 4 deadline: 600 }
 rules { name: "agents_tests/test_reinforce.py" xdist: 4 deadline: 480 }
 rules { name: "agents_tests/test_pcl.py" xdist: 4 deadline: 480 }
 


### PR DESCRIPTION
Several DDPG tests seem to be failing due to timeouts on the ddpg tests. This PR adds time to the DDPG.

E.g. : https://ci.preferred.jp/chainerrl.py3.gpu.slow/49475/
https://ci.preferred.jp/chainerrl.py3.cpu.slow/49125/
