### PR TITLE
Fix CI errors due to pyglet, zipp, mock, and gym

### DIFF
--- a/.pfnci/run.sh
+++ b/.pfnci/run.sh
@@ -86,7 +86,7 @@ main() {
   # TODO(chainerrl): Prepare test target instead.
   # pytest does not run with attrs==19.2.0 (https://github.com/pytest-dev/pytest/issues/3280)  # NOQA
   "${PYTHON}" -m pip install \
-      'pytest==4.1.1' 'attrs==19.1.0' 'pytest-xdist==1.26.1' 'mock<=3.0.5' \
+      'pytest==4.1.1' 'attrs==19.1.0' 'pytest-xdist==1.26.1' \
       'atari_py==0.1.1' 'opencv-python' 'zipp==1.0.0'
 
   git config --global user.email "you@example.com"

--- a/.pfnci/run.sh
+++ b/.pfnci/run.sh
@@ -86,7 +86,7 @@ main() {
   # TODO(chainerrl): Prepare test target instead.
   # pytest does not run with attrs==19.2.0 (https://github.com/pytest-dev/pytest/issues/3280)  # NOQA
   "${PYTHON}" -m pip install \
-      'pytest==4.1.1' 'attrs==19.1.0' 'pytest-xdist==1.26.1' 'mock' \
+      'pytest==4.1.1' 'attrs==19.1.0' 'pytest-xdist==1.26.1' 'mock<=3.0.5' \
       'atari_py==0.1.1' 'opencv-python' 'zipp==1.0.0'
 
   git config --global user.email "you@example.com"

--- a/.pfnci/run.sh
+++ b/.pfnci/run.sh
@@ -87,7 +87,7 @@ main() {
   # pytest does not run with attrs==19.2.0 (https://github.com/pytest-dev/pytest/issues/3280)  # NOQA
   "${PYTHON}" -m pip install \
       'pytest==4.1.1' 'attrs==19.1.0' 'pytest-xdist==1.26.1' 'mock' \
-      'atari_py==0.1.1' 'opencv-python'
+      'atari_py==0.1.1' 'opencv-python' 'zipp==1.0.0'
 
   git config --global user.email "you@example.com"
   git config --global user.name "Your Name"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,9 @@ install:
       pip install chainer
     fi
   - pip install pytest-cov
+  - pip install gym[atari]==0.16.0
   - pip install -r requirements.txt --only-binary=numpy,scipy
   - pip install jupyter
-  # gym 0.11.0 causes an error with Python 2
-  # gym 0.13 requires atari_py 0.2, which is not available in Python 2
-  # atari_py==0.1.4 causes an error
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
-      pip install gym==0.9.7;
-      pip install atari_py==0.1.7;
-    else
-      pip install gym==0.13.0;
-      pip install atari_py==0.2.0;
-    fi
   - pip install autopep8
   - pip install flake8
   - pip install coveralls

--- a/examples/atlas/train_soft_actor_critic_atlas.py
+++ b/examples/atlas/train_soft_actor_critic_atlas.py
@@ -120,8 +120,7 @@ def main():
              for idx, env in enumerate(range(args.num_envs))])
 
     sample_env = make_env(args, process_seeds[0], test=False)
-    timestep_limit = sample_env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = sample_env.spec.max_episode_steps
     obs_space = sample_env.observation_space
     action_space = sample_env.action_space
     print('Observation space:', obs_space)

--- a/examples/atlas/train_soft_actor_critic_atlas.py
+++ b/examples/atlas/train_soft_actor_critic_atlas.py
@@ -26,6 +26,11 @@ def concat_obs_and_action(obs, action):
 
 def make_env(args, seed, test):
     if args.env.startswith('Roboschool'):
+        # Check gym version because roboschool does not work with gym>=0.15.6
+        from distutils.version import StrictVersion
+        gym_version = StrictVersion(gym.__version__)
+        if gym_version >= StrictVersion('0.15.6'):
+            raise RuntimeError('roboschool does not work with gym>=0.15.6')
         import roboschool  # NOQA
     env = gym.make(args.env)
     # Unwrap TimiLimit wrapper

--- a/examples/gym/train_a2c_gym.py
+++ b/examples/gym/train_a2c_gym.py
@@ -150,8 +150,7 @@ def main():
              for idx, env in enumerate(range(args.num_envs))])
 
     sample_env = make_env(process_idx=0, test=False)
-    timestep_limit = sample_env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = sample_env.spec.max_episode_steps
     obs_space = sample_env.observation_space
     action_space = sample_env.action_space
 

--- a/examples/gym/train_a3c_gym.py
+++ b/examples/gym/train_a3c_gym.py
@@ -149,8 +149,7 @@ def main():
         return env
 
     sample_env = gym.make(args.env)
-    timestep_limit = sample_env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = sample_env.spec.max_episode_steps
     obs_space = sample_env.observation_space
     action_space = sample_env.action_space
 

--- a/examples/gym/train_acer_gym.py
+++ b/examples/gym/train_acer_gym.py
@@ -95,8 +95,7 @@ def main():
         return env
 
     sample_env = gym.make(args.env)
-    timestep_limit = sample_env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = sample_env.spec.max_episode_steps
     obs_space = sample_env.observation_space
     action_space = sample_env.action_space
 

--- a/examples/gym/train_categorical_dqn_gym.py
+++ b/examples/gym/train_categorical_dqn_gym.py
@@ -83,8 +83,7 @@ def main():
         return env
 
     env = make_env(test=False)
-    timestep_limit = env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = env.spec.max_episode_steps
     obs_size = env.observation_space.low.size
     action_space = env.action_space
 

--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -99,8 +99,7 @@ def main():
         return env
 
     env = make_env(test=False)
-    timestep_limit = env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = env.spec.max_episode_steps
     obs_space = env.observation_space
     obs_size = obs_space.low.size
     action_space = env.action_space

--- a/examples/gym/train_iqn_gym.py
+++ b/examples/gym/train_iqn_gym.py
@@ -81,8 +81,7 @@ def main():
         return env
 
     env = make_env(test=False)
-    timestep_limit = env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = env.spec.max_episode_steps
     obs_size = env.observation_space.low.size
     action_space = env.action_space
 

--- a/examples/gym/train_pcl_gym.py
+++ b/examples/gym/train_pcl_gym.py
@@ -110,8 +110,7 @@ def main():
         return env
 
     sample_env = gym.make(args.env)
-    timestep_limit = sample_env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = sample_env.spec.max_episode_steps
     obs_space = sample_env.observation_space
     action_space = sample_env.action_space
 

--- a/examples/gym/train_reinforce_gym.py
+++ b/examples/gym/train_reinforce_gym.py
@@ -72,8 +72,7 @@ def main():
         return env
 
     train_env = make_env(test=False)
-    timestep_limit = train_env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = train_env.spec.max_episode_steps
     obs_space = train_env.observation_space
     action_space = train_env.action_space
 

--- a/examples/mujoco/reproduction/ddpg/train_ddpg.py
+++ b/examples/mujoco/reproduction/ddpg/train_ddpg.py
@@ -96,8 +96,7 @@ def main():
         return env
 
     env = make_env(test=False)
-    timestep_limit = env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = env.spec.max_episode_steps
     obs_space = env.observation_space
     action_space = env.action_space
     print('Observation space:', obs_space)

--- a/examples/mujoco/reproduction/ppo/train_ppo.py
+++ b/examples/mujoco/reproduction/ppo/train_ppo.py
@@ -98,8 +98,7 @@ def main():
 
     # Only for getting timesteps, and obs-action spaces
     sample_env = gym.make(args.env)
-    timestep_limit = sample_env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = sample_env.spec.max_episode_steps
     obs_space = sample_env.observation_space
     action_space = sample_env.action_space
     print('Observation space:', obs_space)

--- a/examples/mujoco/reproduction/soft_actor_critic/train_soft_actor_critic.py
+++ b/examples/mujoco/reproduction/soft_actor_critic/train_soft_actor_critic.py
@@ -119,8 +119,7 @@ def main():
              for idx, env in enumerate(range(args.num_envs))])
 
     sample_env = make_env(process_idx=0, test=False)
-    timestep_limit = sample_env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = sample_env.spec.max_episode_steps
     obs_space = sample_env.observation_space
     action_space = sample_env.action_space
     print('Observation space:', obs_space)

--- a/examples/mujoco/reproduction/td3/train_td3.py
+++ b/examples/mujoco/reproduction/td3/train_td3.py
@@ -94,8 +94,7 @@ def main():
         return env
 
     env = make_env(test=False)
-    timestep_limit = env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = env.spec.max_episode_steps
     obs_space = env.observation_space
     action_space = env.action_space
     print('Observation space:', obs_space)

--- a/examples/mujoco/reproduction/trpo/train_trpo.py
+++ b/examples/mujoco/reproduction/trpo/train_trpo.py
@@ -77,8 +77,7 @@ def main():
         return env
 
     env = make_env(test=False)
-    timestep_limit = env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = env.spec.max_episode_steps
     obs_space = env.observation_space
     action_space = env.action_space
     print('Observation space:', obs_space)

--- a/examples/mujoco/train_ddpg_batch_gym.py
+++ b/examples/mujoco/train_ddpg_batch_gym.py
@@ -104,8 +104,7 @@ def main():
              for idx, env in enumerate(range(args.num_envs))])
 
     sample_env = make_env(0, test=False)
-    timestep_limit = sample_env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = sample_env.spec.max_episode_steps
 
     obs_size = np.asarray(sample_env.observation_space.shape).prod()
     action_space = sample_env.action_space

--- a/examples/mujoco/train_ddpg_gym.py
+++ b/examples/mujoco/train_ddpg_gym.py
@@ -90,8 +90,7 @@ def main():
         return env
 
     env = make_env(test=False)
-    timestep_limit = env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = env.spec.max_episode_steps
     obs_size = np.asarray(env.observation_space.shape).prod()
     action_space = env.action_space
 

--- a/examples/mujoco/train_ppo_batch_gym.py
+++ b/examples/mujoco/train_ppo_batch_gym.py
@@ -94,8 +94,7 @@ def main():
 
     # Only for getting timesteps, and obs-action spaces
     sample_env = gym.make(args.env)
-    timestep_limit = sample_env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = sample_env.spec.max_episode_steps
     obs_space = sample_env.observation_space
     action_space = sample_env.action_space
 

--- a/examples/mujoco/train_ppo_gym.py
+++ b/examples/mujoco/train_ppo_gym.py
@@ -130,8 +130,7 @@ def main():
         return env
 
     sample_env = gym.make(args.env)
-    timestep_limit = sample_env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = sample_env.spec.max_episode_steps
     obs_space = sample_env.observation_space
     action_space = sample_env.action_space
 

--- a/examples/mujoco/train_trpo_gym.py
+++ b/examples/mujoco/train_trpo_gym.py
@@ -80,8 +80,7 @@ def main():
         return env
 
     env = make_env(test=False)
-    timestep_limit = env.spec.tags.get(
-        'wrapper_config.TimeLimit.max_episode_steps')
+    timestep_limit = env.spec.max_episode_steps
     obs_space = env.observation_space
     action_space = env.action_space
     print('Observation space:', obs_space)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@
 autopep8
 atari_py
 flake8
-mock
 opencv-python
 pytest
 sphinx

--- a/tests/experiments_tests/test_collect_demos.py
+++ b/tests/experiments_tests/test_collect_demos.py
@@ -1,10 +1,10 @@
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 import chainer
 from chainer import testing
-import mock
 
 import chainerrl.experiments as experiments
 

--- a/tests/experiments_tests/test_evaluator.py
+++ b/tests/experiments_tests/test_evaluator.py
@@ -1,8 +1,8 @@
 import tempfile
 import unittest
+from unittest import mock
 
 from chainer import testing
-import mock
 
 import chainerrl
 from chainerrl.experiments import evaluator

--- a/tests/experiments_tests/test_train_agent.py
+++ b/tests/experiments_tests/test_train_agent.py
@@ -1,7 +1,6 @@
 import tempfile
 import unittest
-
-import mock
+from unittest import mock
 
 import chainerrl
 

--- a/tests/experiments_tests/test_train_agent_async.py
+++ b/tests/experiments_tests/test_train_agent_async.py
@@ -2,9 +2,9 @@ import multiprocessing as mp
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 from chainer import testing
-import mock
 
 import chainerrl
 from chainerrl.experiments.train_agent_async import train_loop

--- a/tests/experiments_tests/test_train_agent_async.py
+++ b/tests/experiments_tests/test_train_agent_async.py
@@ -88,7 +88,7 @@ class TestTrainAgentAsync(unittest.TestCase):
 
         # All the envs (including eval envs) should to be closed
         for env in envs + eval_envs:
-            env.close.assert_called_once()
+            assert env.close.call_count == 1
 
         if self.num_envs == 1:
             self.assertEqual(hook.call_count, steps)

--- a/tests/experiments_tests/test_train_agent_batch.py
+++ b/tests/experiments_tests/test_train_agent_batch.py
@@ -1,9 +1,9 @@
 import math
 import tempfile
 import unittest
+from unittest import mock
 
 from chainer import testing
-import mock
 
 import chainerrl
 

--- a/tests/wrappers_tests/test_atari_wrappers.py
+++ b/tests/wrappers_tests/test_atari_wrappers.py
@@ -2,8 +2,8 @@
 only."""
 
 
-import mock
 import unittest
+from unittest import mock
 
 from chainer import testing
 import gym

--- a/tests/wrappers_tests/test_continuing_time_limit.py
+++ b/tests/wrappers_tests/test_continuing_time_limit.py
@@ -1,5 +1,5 @@
-import mock
 import unittest
+from unittest import mock
 
 from chainer import testing
 

--- a/tests/wrappers_tests/test_render.py
+++ b/tests/wrappers_tests/test_render.py
@@ -1,7 +1,7 @@
 import unittest
+from unittest import mock
 
 from chainer import testing
-import mock
 
 import chainerrl
 

--- a/tests/wrappers_tests/test_vector_frame_stack.py
+++ b/tests/wrappers_tests/test_vector_frame_stack.py
@@ -1,6 +1,6 @@
 import functools
-import mock
 import unittest
+from unittest import mock
 
 from chainer import testing
 import gym


### PR DESCRIPTION
- Use newer gym because old `gym` does not work with pyglet>=1.4.
- Modify some example scripts that are not compatible with newer gym.
- Use zipp==1.0.0 in flexCI because new zipp does not work with Python 3.5.
- Remove mock from dependency as we do not support py2 now.