### PR TITLE
Basic Script Fix

### DIFF
--- a/examples/atari/reproduction/a3c/train_a3c.py
+++ b/examples/atari/reproduction/a3c/train_a3c.py
@@ -169,7 +169,7 @@ def main():
             eval_n_episodes=None,
             eval_interval=args.eval_interval,
             global_step_hooks=[lr_decay_hook],
-            save_best_so_far_agent=False,
+            save_best_so_far_agent=True,
         )
 
 


### PR DESCRIPTION
Since the best network is the reported score for A3C, we want to store the best network for the model release.