### PR TITLE
Uses posix to avoid path issues for windows users

### DIFF
--- a/chainerrl/misc/pretrained_models.py
+++ b/chainerrl/misc/pretrained_models.py
@@ -123,7 +123,7 @@ def download_and_store_model(alg, url, env, model_type):
         is_cached = os.path.exists(path)
         if not is_cached:
             cache_path = cached_download(posixpath.join(url_basepath,
-                                         file))
+                                                        file))
             os.rename(cache_path, path)
             with zipfile.ZipFile(path, 'r') as zip_ref:
                 zip_ref.extractall(root)

--- a/chainerrl/misc/pretrained_models.py
+++ b/chainerrl/misc/pretrained_models.py
@@ -123,7 +123,7 @@ def download_and_store_model(alg, url, env, model_type):
         is_cached = os.path.exists(path)
         if not is_cached:
             cache_path = cached_download(posixpath.join(url_basepath,
-                                                      file))
+                                         file))
             os.rename(cache_path, path)
             with zipfile.ZipFile(path, 'r') as zip_ref:
                 zip_ref.extractall(root)

--- a/chainerrl/misc/pretrained_models.py
+++ b/chainerrl/misc/pretrained_models.py
@@ -5,6 +5,7 @@ https://github.com/chainer/chainercv/blob/master/chainercv/utils/download.py
 import filelock
 import hashlib
 import os
+import posixpath
 import shutil
 import tempfile
 import time
@@ -116,12 +117,12 @@ def download_and_store_model(alg, url, env, model_type):
             'models.lock')):
         root = get_dataset_directory(
             os.path.join('pfnet', 'chainerrl', 'models', alg, env))
-        url_basepath = os.path.join(url, alg, env)
+        url_basepath = posixpath.join(url, alg, env)
         file = model_type + ".zip"
         path = os.path.join(root, file)
         is_cached = os.path.exists(path)
         if not is_cached:
-            cache_path = cached_download(os.path.join(url_basepath,
+            cache_path = cached_download(posixpath.join(url_basepath,
                                                       file))
             os.rename(cache_path, path)
             with zipfile.ZipFile(path, 'r') as zip_ref:


### PR DESCRIPTION
Resolves https://github.com/chainer/chainerrl/issues/551

I haven't tested with windows, but this fix should work. The issue with windows was that os.path.join uses windows file paths, so downloading from the web uses windows file paths breaks. This explicitly uses posix paths instead.

I've tested an example model download with this updated code and it works. Also note that the model download is tested in the CI.