### PR TITLE
Create a copy of agent in evaluation for  chainerrl/experiements/train_agent_async.py

### DIFF
--- a/chainerrl/experiments/train_agent_async.py
+++ b/chainerrl/experiments/train_agent_async.py
@@ -1,7 +1,7 @@
 import logging
 import multiprocessing as mp
 import os
-
+import copy
 from chainerrl.experiments.evaluator import AsyncEvaluator
 from chainerrl.misc import async_
 from chainerrl.misc import random_seed
@@ -63,7 +63,7 @@ def train_loop(process_idx, env, agent, steps, outdir, counter,
                 if evaluator is not None:
                     eval_score = evaluator.evaluate_if_necessary(
                         t=global_t, episodes=global_episodes,
-                        env=eval_env, agent=agent)
+                        env=eval_env, agent=copy.deepcopy(agent))
                     if (eval_score is not None and
                             successful_score is not None and
                             eval_score >= successful_score):


### PR DESCRIPTION
I am a user of channerl, and my code break if I use the same agent to evaluate (note that in train&evaluation, env could be different), so I request to change to copy an agent